### PR TITLE
店舗追加画面にメニュー項目を追加する

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -28,6 +28,8 @@
 
     <!-- Edit Area Screen -->
     <string name="editarea_change_image_button">画像を変更する</string>
+    <string name="editarea_delete_button">削除する</string>
+    <string name="editarea_edit_button">変更する</string>
     <string name="editarea_delete_confirm">%1$sを削除して良いですか？</string>
     <string name="editarea_title">編集</string>
     <string name="editarea_image_load_error">画像の読み込みに失敗しました: </string>
@@ -42,7 +44,9 @@
     <string name="add_category_label">系統</string>
     
     <!-- Add Shop Screen -->
+    <string name="add_shop_area">エリア</string>
     <string name="add_shop_title">登録</string>
+    <string name="add_shop_add_button">登録する</string>
     <string name="add_shop_name_label">名前</string>
     <string name="add_shop_photo_label">写真</string>
     <string name="add_shop_select_button">選択</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -49,7 +49,8 @@
     <string name="add_shop_no_image">No Image</string>
     <string name="add_shop_register_button">登録</string>
     <string name="add_shop_option1">Option 1</string>
-    
+    <string name="add_shop_menu_name_label">メニュー</string>
+
     <!-- App -->
     <string name="app_name">ラーメンノート</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ShopEntity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ShopEntity.kt
@@ -12,7 +12,14 @@ data class ShopEntity(
     val mapUrl: String,
     val star: Int,
     val stationName: String,
-    val imageName1: String,
-    val imageName2: String,
-    val imageName3: String,
+    val category: String,
+    val menuName1: String,
+    val menuName2: String,
+    val menuName3: String,
+    val photoName1: String,
+    val photoName2: String,
+    val photoName3: String,
+    val description1: String,
+    val description2: String,
+    val description3: String
 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
@@ -58,7 +58,16 @@ private fun ShopEntity.toDomainModel(): Shop {
         mapUrl = mapUrl,
         star = star,
         stationName = stationName,
-        category = "" // ShopEntityにはcategoryがないので空文字を設定
+        category = category,
+        menuName1 = menuName1,
+        menuName2 = menuName2,
+        menuName3 = menuName3,
+        photoName1 = photoName1,
+        photoName2 = photoName2,
+        photoName3 = photoName3,
+        description1 = description1,
+        description2 = description2,
+        description3 = description3
     )
 }
 
@@ -70,8 +79,15 @@ private fun Shop.toEntity(): ShopEntity {
         mapUrl = mapUrl,
         star = star,
         stationName = stationName,
-        imageName1 = "", // 画像名は空文字で初期化
-        imageName2 = "",
-        imageName3 = ""
+        category = category,
+        menuName1 = menuName1,
+        menuName2 = menuName2,
+        menuName3 = menuName3,
+        photoName1 = photoName1,
+        photoName2 = photoName2,
+        photoName3 = photoName3,
+        description1 = description1,
+        description2 = description2,
+        description3 = description3
     )
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -8,6 +8,8 @@ import dev.seabat.ramennote.domain.usecase.FetchUnsplashImageUseCase
 import dev.seabat.ramennote.domain.usecase.FetchUnsplashImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCase
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.SaveShopMenuImageUseCase
+import dev.seabat.ramennote.domain.usecase.SaveShopMenuImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCase
 import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCaseContract
 import org.koin.dsl.module
@@ -19,4 +21,5 @@ val useCaseModule = module {
     single<FetchUnsplashImageUseCaseContract> { FetchUnsplashImageUseCase(get(), get()) }
     single<UpdateAreaUseCaseContract> { UpdateAreaUseCase(get(), get()) }
     single<DeleteAreaUseCaseContract> { DeleteAreaUseCase(get(), get()) }
+    single<SaveShopMenuImageUseCaseContract> { SaveShopMenuImageUseCase(get()) }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Shop.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Shop.kt
@@ -12,7 +12,16 @@ data class Shop(
     val mapUrl: String = "",
     val star: Int = 0,
     val stationName: String = "",
-    val category: String = ""
+    val category: String = "",
+    val menuName1: String = "",
+    val menuName2: String = "",
+    val menuName3: String = "",
+    val photoName1: String = "",
+    val photoName2: String = "",
+    val photoName3: String = "",
+    val description1: String = "",
+    val description2: String = "",
+    val description3: String = ""
 ) {
     fun toJsonString(): String {
         return Json.encodeToString(this)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/SaveShopMenuImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/SaveShopMenuImageUseCase.kt
@@ -1,0 +1,11 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.LocalAreaImageRepositoryContract
+
+class SaveShopMenuImageUseCase(
+    private val localAreaImageRepository: LocalAreaImageRepositoryContract
+) : SaveShopMenuImageUseCaseContract {
+    override suspend operator fun invoke(fileName: String, byteArray: ByteArray) {
+        localAreaImageRepository.save(byteArray, fileName)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/SaveShopMenuImageUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/SaveShopMenuImageUseCaseContract.kt
@@ -1,0 +1,6 @@
+package dev.seabat.ramennote.domain.usecase
+
+
+interface SaveShopMenuImageUseCaseContract {
+    suspend operator fun invoke(fileName: String, byteArray: ByteArray)
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/component/MaxWidthButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/component/MaxWidthButton.kt
@@ -1,0 +1,36 @@
+package dev.seabat.ramennote.ui.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MaxWidthButton(
+    text: String,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = {
+            onClick()
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 24.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+        ),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Text(text = text, style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+
+

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModleModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModleModule.kt
@@ -12,6 +12,6 @@ val viewModelModule = module {
     viewModel { EditAreaViewModel(get(), get(), get(), get()) }
     viewModel { AddAreaViewModel(get(), get()) }
     viewModel { NoteViewModel(get(), get()) }
-    viewModel { AddShopViewModel(get()) }
+    viewModel { AddShopViewModel(get(), get()) }
     viewModel { AreaShopListViewModel(get()) }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -104,8 +104,8 @@ private fun MainContent(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp),
-            containerColor = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onError
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         ) {
             Icon(
                 imageVector = Icons.Default.Add,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -27,15 +25,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.ui.component.AppAlert
 import dev.seabat.ramennote.ui.component.AppBar
 import dev.seabat.ramennote.ui.component.AppProgressBar
+import dev.seabat.ramennote.ui.component.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.add_shop_add_button
+import ramennote.composeapp.generated.resources.add_shop_area
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,12 +75,21 @@ fun AddAreaScreen(
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
                 Column(modifier = Modifier.fillMaxWidth().padding(top = 24.dp)) {
-                    Text(text = "エリア", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        text = stringResource(Res.string.add_shop_area),
+                        style = MaterialTheme.typography.titleMedium
+                    )
                     Spacer(Modifier.height(8.dp))
                     OutlinedTextField(
                         value = areaName,
                         onValueChange = { areaName = it },
                         modifier = Modifier.fillMaxWidth(),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.outline,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                            disabledBorderColor = MaterialTheme.colorScheme.outline,
+                            errorBorderColor = MaterialTheme.colorScheme.error
+                        ),
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(
                             onDone = { focusManager.clearFocus() }
@@ -84,23 +97,10 @@ fun AddAreaScreen(
                     )
                     Spacer(Modifier.height(16.dp))
                 }
-
-                Button(
-                    onClick = {
-                        if (areaName.isNotBlank()) {
-                            viewModel.addArea(areaName)
-                        }
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 24.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-                    ),
-                    shape = MaterialTheme.shapes.medium
-                ) {
-                    Text(text = "登録する", style = MaterialTheme.typography.titleMedium)
+                MaxWidthButton(stringResource(Res.string.add_shop_add_button)) {
+                    if (areaName.isNotBlank()) {
+                        viewModel.addArea(areaName)
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -45,6 +45,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import ramennote.composeapp.generated.resources.Res
 import ramennote.composeapp.generated.resources.add_evaluation_label
 import ramennote.composeapp.generated.resources.add_map_label
+import ramennote.composeapp.generated.resources.add_shop_menu_name_label
 import ramennote.composeapp.generated.resources.add_shop_name_label
 import ramennote.composeapp.generated.resources.add_shop_no_image
 import ramennote.composeapp.generated.resources.add_shop_option1
@@ -69,6 +70,7 @@ fun AddShopScreen(
     var stationName by remember { mutableStateOf("") }
     val focusManager = LocalFocusManager.current
     var category by remember { mutableStateOf("") }
+    var menuName by remember { mutableStateOf("") }
 
     val saveState by viewModel.saveState.collectAsState()
 
@@ -193,13 +195,13 @@ fun AddShopScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 写真
-            PhotoSelectionField(
-                label = stringResource(Res.string.add_shop_photo_label),
+            // ラーメン
+            ramen(
+                menuName = menuName,
                 imageBitmap = imageBitmap,
-            ) {
-                permissionEnabled = true
-            }
+                enablePermission = { permissionEnabled = true },
+                onMenuValueChange = {}
+            )
 
             Spacer(modifier = Modifier.height(32.dp))
 
@@ -285,6 +287,62 @@ private fun Permission(
     } else {
         logd("ramen-note", "GALLERY Permission: not Granted")
         permissionLauncher.askPermission(PermissionType.GALLERY)
+    }
+}
+
+@Composable
+private fun ramen(
+    menuName: String = "",
+    imageBitmap:ImageBitmap?,
+    enablePermission: () -> Unit,
+    onMenuValueChange: (String) -> Unit
+) {
+    Box(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        // メインのBox
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .border(
+                    width = 1.dp,
+                    color = Color.Black,
+                    shape = RoundedCornerShape(10.dp)
+                )
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.Start
+            ) {
+                ShopInputField(
+                    label = stringResource(Res.string.add_shop_menu_name_label),
+                    value = menuName,
+                    onValueChange =onMenuValueChange
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 写真
+                PhotoSelectionField(
+                    label = stringResource(Res.string.add_shop_photo_label),
+                    imageBitmap = imageBitmap,
+                    onClick = enablePermission
+                )
+            }
+        }
+        
+        // タイトルをborder上に配置
+        Text(
+            text = "メニュー情報",
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(x = 16.dp, y = (-8).dp) // 位置調整
+                .background(Color.White)
+                .padding(horizontal = 4.dp),
+            style = MaterialTheme.typography.bodySmall
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +28,7 @@ import dev.seabat.ramennote.domain.util.logd
 import dev.seabat.ramennote.ui.component.AppBar
 import dev.seabat.ramennote.ui.component.AppAlert
 import dev.seabat.ramennote.ui.component.AppTwoButtonAlert
+import dev.seabat.ramennote.ui.component.MaxWidthButton
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import dev.seabat.ramennote.ui.gallery.createRememberedGalleryLauncher
 import dev.seabat.ramennote.ui.permission.PermissionCallback
@@ -38,8 +37,6 @@ import dev.seabat.ramennote.ui.permission.PermissionType
 import dev.seabat.ramennote.ui.permission.createRememberedPermissionsLauncher
 import dev.seabat.ramennote.ui.permission.launchSettings
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toLocalDateTime
@@ -52,7 +49,6 @@ import ramennote.composeapp.generated.resources.add_map_label
 import ramennote.composeapp.generated.resources.add_shop_menu_name_label
 import ramennote.composeapp.generated.resources.add_shop_name_label
 import ramennote.composeapp.generated.resources.add_shop_no_image
-import ramennote.composeapp.generated.resources.add_shop_option1
 import ramennote.composeapp.generated.resources.add_shop_photo_label
 import ramennote.composeapp.generated.resources.add_shop_register_button
 import ramennote.composeapp.generated.resources.add_shop_select_button
@@ -204,44 +200,29 @@ fun AddShopScreen(
 
             // 登録ボタン
             val isButtonEnabled = name.isNotBlank() && areaName.isNotBlank()
-            
-            Button(
-                onClick = {
-                    val now = Clock.System.now().toLocalDateTime(
-                        kotlinx.datetime.TimeZone.currentSystemDefault()
-                    )
-                    val currentTime = "${now.year}${now.monthNumber.toString()
-                        .padStart(2, '0')}${now.dayOfMonth.toString()
-                            .padStart(2, '0')}T${now.hour.toString()
-                                .padStart(2, '0')}${now.minute.toString()
-                                    .padStart(2, '0')}${now.second.toString()
-                                        .padStart(2, '0')}"
-                    val shop = Shop(
-                        name = name,
-                        area = areaName,
-                        shopUrl = shopUrl,
-                        mapUrl = mapUrl,
-                        star = star,
-                        stationName = stationName,
-                        category = category,
-                        menuName1 = menuName,
-                        photoName1 = if (sharedImage != null) currentTime + "_1" else ""
-                    )
-                    viewModel.saveShop(shop, sharedImage)
-                },
-                enabled = isButtonEnabled,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary
+
+            MaxWidthButton(stringResource(Res.string.add_shop_register_button)) {
+                val now = Clock.System.now().toLocalDateTime(
+                    kotlinx.datetime.TimeZone.currentSystemDefault()
                 )
-            ) {
-                Text(
-                    text = stringResource(Res.string.add_shop_register_button),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onPrimary
+                val currentTime = "${now.year}${now.monthNumber.toString()
+                    .padStart(2, '0')}${now.dayOfMonth.toString()
+                    .padStart(2, '0')}T${now.hour.toString()
+                    .padStart(2, '0')}${now.minute.toString()
+                    .padStart(2, '0')}${now.second.toString()
+                    .padStart(2, '0')}"
+                val shop = Shop(
+                    name = name,
+                    area = areaName,
+                    shopUrl = shopUrl,
+                    mapUrl = mapUrl,
+                    star = star,
+                    stationName = stationName,
+                    category = category,
+                    menuName1 = menuName,
+                    photoName1 = if (sharedImage != null) currentTime + "_1" else ""
                 )
+                viewModel.saveShop(shop, sharedImage)
             }
         }
     }
@@ -314,7 +295,7 @@ private fun Ramen(
                 .fillMaxWidth()
                 .border(
                     width = 1.dp,
-                    color = Color.Black,
+                    color = MaterialTheme.colorScheme.outline,
                     shape = RoundedCornerShape(10.dp)
                 )
                 .padding(16.dp),
@@ -368,12 +349,20 @@ private fun ShopInputField(
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Medium
         )
+        
         Spacer(modifier = Modifier.height(8.dp))
+        
         OutlinedTextField(
             value = value,
             onValueChange = onValueChange,
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.outline,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                disabledBorderColor = MaterialTheme.colorScheme.outline,
+                errorBorderColor = MaterialTheme.colorScheme.error
+            ),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(
                 onDone = { focusManager.clearFocus() }
@@ -411,6 +400,12 @@ private fun StarDropdownField(
                 modifier = Modifier
                     .fillMaxWidth()
                     .menuAnchor(),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.outline,
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                    disabledBorderColor = MaterialTheme.colorScheme.outline,
+                    errorBorderColor = MaterialTheme.colorScheme.error
+                ),
                 trailingIcon = {
                     ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                 }
@@ -425,55 +420,6 @@ private fun StarDropdownField(
                         onClick = {
                             val intValue = if (option.isEmpty()) 0 else option.toIntOrNull() ?: 0
                             onValueChange(intValue)
-                            expanded = false
-                        }
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ShopDropdownField(
-    label: String,
-    value: String,
-    onValueChange: (String) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val options = listOf("Option 1", "Option 2", "Option 3")
-
-    Column {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            fontWeight = FontWeight.Medium
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Box {
-            OutlinedTextField(
-                value = value.ifEmpty { stringResource(Res.string.add_shop_option1) },
-                onValueChange = { },
-                readOnly = true,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = true },
-                trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = null
-                    )
-                }
-            )
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false }
-            ) {
-                options.forEach { option ->
-                    DropdownMenuItem(
-                        text = { Text(option) },
-                        onClick = {
-                            onValueChange(option)
                             expanded = false
                         }
                     )
@@ -528,7 +474,7 @@ private fun PhotoSelectionField(
                         .size(80.dp)
                         .border(
                             width = 1.dp,
-                            color = Color.Black,
+                            color = MaterialTheme.colorScheme.outline,
                             shape = RoundedCornerShape(4.dp)
                         )
                         .background(Color.White),

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -39,6 +39,8 @@ import dev.seabat.ramennote.ui.permission.launchSettings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -196,11 +198,11 @@ fun AddShopScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             // ラーメン
-            ramen(
+            Ramen(
                 menuName = menuName,
                 imageBitmap = imageBitmap,
                 enablePermission = { permissionEnabled = true },
-                onMenuValueChange = {}
+                onMenuValueChange = { menuName = it }
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -210,6 +212,15 @@ fun AddShopScreen(
             
             Button(
                 onClick = {
+                    val now = Clock.System.now().toLocalDateTime(
+                        kotlinx.datetime.TimeZone.currentSystemDefault()
+                    )
+                    val currentTime = "${now.year}${now.monthNumber.toString()
+                        .padStart(2, '0')}${now.dayOfMonth.toString()
+                            .padStart(2, '0')}T${now.hour.toString()
+                                .padStart(2, '0')}${now.minute.toString()
+                                    .padStart(2, '0')}${now.second.toString()
+                                        .padStart(2, '0')}"
                     val shop = Shop(
                         name = name,
                         area = areaName,
@@ -217,7 +228,9 @@ fun AddShopScreen(
                         mapUrl = mapUrl,
                         star = star,
                         stationName = stationName,
-                        category = category
+                        category = category,
+                        menuName1 = menuName,
+                        photoName1 = if (imageBitmap != null) currentTime + "_1" else ""
                     )
                     viewModel.saveShop(shop)
                 },
@@ -291,7 +304,7 @@ private fun Permission(
 }
 
 @Composable
-private fun ramen(
+private fun Ramen(
     menuName: String = "",
     imageBitmap:ImageBitmap?,
     enablePermission: () -> Unit,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModel.kt
@@ -1,25 +1,36 @@
 package dev.seabat.ramennote.ui.screens.note.addshop
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.SaveShopMenuImageUseCaseContract
+import dev.seabat.ramennote.ui.gallery.SharedImage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class AddShopViewModel(
-    private val shopsRepository: ShopsRepositoryContract
+    private val shopsRepository: ShopsRepositoryContract,
+    private val saveShopMenuImageUseCase: SaveShopMenuImageUseCaseContract
 ) : ViewModel(), AddShopViewModelContract {
 
     private val _saveState = MutableStateFlow<RunStatus<String>>(RunStatus.Idle())
     override val saveState: StateFlow<RunStatus<String>> = _saveState
 
-    override fun saveShop(shop: Shop) {
+    override fun saveShop(shop: Shop, sharedImage: SharedImage?) {
         viewModelScope.launch {
             _saveState.value = RunStatus.Loading()
             try {
+                // 画像を保存
+                if (sharedImage != null && shop.photoName1.isNotEmpty()) {
+                    val byteArray = sharedImage.toByteArray()
+                    saveShopMenuImageUseCase(shop.photoName1, byteArray!!)
+                }
+                
+                // 店舗情報を保存
                 shopsRepository.insertShop(shop)
                 _saveState.value = RunStatus.Success("")
             } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModelContract.kt
@@ -2,9 +2,10 @@ package dev.seabat.ramennote.ui.screens.note.addshop
 
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.ui.gallery.SharedImage
 import kotlinx.coroutines.flow.StateFlow
 
 interface AddShopViewModelContract {
     val saveState: StateFlow<RunStatus<String>>
-    fun saveShop(shop: Shop)
+    fun saveShop(shop: Shop, sharedImage: SharedImage?)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/MockAddShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/MockAddShopViewModel.kt
@@ -2,6 +2,7 @@ package dev.seabat.ramennote.ui.screens.note.addshop
 
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.ui.gallery.SharedImage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,7 +11,7 @@ class MockAddShopViewModel : AddShopViewModelContract {
     private val _saveState: MutableStateFlow<RunStatus<String>> = MutableStateFlow(RunStatus.Idle())
     override val saveState: StateFlow<RunStatus<String>> = _saveState.asStateFlow()
 
-    override fun saveShop(shop: Shop) {
+    override fun saveShop(shop: Shop, sharedImage: SharedImage?) {
         // Preview用なので何もしない
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.RunStatus
@@ -40,9 +41,12 @@ import ramennote.composeapp.generated.resources.editarea_title
 import ramennote.composeapp.generated.resources.editarea_delete_confirm
 import dev.seabat.ramennote.ui.component.AppBar
 import dev.seabat.ramennote.ui.component.AppProgressBar
+import dev.seabat.ramennote.ui.component.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import ramennote.composeapp.generated.resources.editarea_delete_button
+import ramennote.composeapp.generated.resources.editarea_edit_button
 import ramennote.composeapp.generated.resources.editarea_image_load_error
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -95,6 +99,12 @@ fun EditAreaScreen(
                         value = areaName,
                         onValueChange = { areaName = it },
                         modifier = Modifier.fillMaxWidth(),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = MaterialTheme.colorScheme.outline,
+                            unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                            disabledBorderColor = MaterialTheme.colorScheme.outline,
+                            errorBorderColor = MaterialTheme.colorScheme.error
+                        ),
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                         keyboardActions = KeyboardActions(
                             onDone = { focusManager.clearFocus() }
@@ -172,38 +182,11 @@ fun BottomContent(
     onDeleteButtonClick: () -> Unit,
 ) {
     Column {
-        Button(
-            onClick = {
-                if (areaName.isNotBlank()) {
-                    onEditButtonClick()
-                }
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 24.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-            ),
-            shape = MaterialTheme.shapes.medium
-        ) {
-            Text(text = "変更する", style = MaterialTheme.typography.titleMedium)
+        MaxWidthButton(stringResource(Res.string.editarea_edit_button)) {
+            onEditButtonClick()
         }
-
-        Button(
-            onClick = {
-                onDeleteButtonClick()
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 24.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-            ),
-            shape = MaterialTheme.shapes.medium
-        ) {
-            Text(text = "削除する", style = MaterialTheme.typography.titleMedium)
+        MaxWidthButton(stringResource(Res.string.editarea_delete_button)) {
+            onDeleteButtonClick()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
@@ -90,7 +90,7 @@ private fun AreaShopListMainContent(
         ) {
             item {
                 Divider(
-                    color = Color.Gray.copy(alpha = 0.3f),
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
                     thickness = 1.dp
                 )
             }
@@ -109,8 +109,8 @@ private fun AreaShopListMainContent(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp),
-            containerColor = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onError
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
         ) {
             Icon(
                 imageVector = Icons.Default.Add,
@@ -161,7 +161,7 @@ private fun ShopItem(
             }
         }
         Divider(
-            color = Color.Gray.copy(alpha = 0.3f),
+            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
             thickness = 1.dp
         )
     }


### PR DESCRIPTION

### 概要
* メニュー情報の保存機能を追加し、画像保存フローとUIスタイルを統一しました。
* ドメイン/DBスキーマ拡張、画像保存UseCase導入、入力UIの改善を含みます。

### 変更点
* ドメイン/DB
    * Shopに以下を追加: menuName1-3, photoName1-3, description1-3
    * ShopEntityへ同項目を追加
    * ShopsRepositoryのtoDomainModel/toEntityを更新
* 画像保存フロー
    * AddShopScreen: 登録時にmenuName1へ入力値を保存
    * 画像ありの場合、kotlinx-datetimeでyyyyMMddTHHmmssを生成し、_1付与してphotoName1に設定
    * viewModel.saveShop(shop, sharedImage)でSharedImageを渡す
    * AddShopViewModel: SharedImage.toByteArray()→SaveShopMenuImageUseCaseContract→LocalAreaImageRepository.save(byteArray, fileName)
    * SaveShopMenuImageUseCase作成とSaveShopMenuImageUseCaseContract化
* UI/スタイル
    * OutlinedTextFieldとBox.borderの色をMaterialTheme.colorScheme.outlineに統一
    * AddAreaScreen/EditAreaScreenのボタンをMaxWidthButtonへ置き換え
    * 文言のリソース化（追加/編集/削除ボタン、エリアラベル等）
    * LaunchedEffect内の非同期処理を簡潔化（withContext(Dispatchers.Default)で画像変換）
    * AddShopの入力コンポーネント名をRamenへ整理