### PR TITLE
エリア別レポート一覧機能の追加とバグ修正

### DIFF
--- a/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/MainActivity.kt
@@ -14,8 +14,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        // タスク一覧でアプリ画面の内容を非表示にする（常時有効）
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        // タスク一覧でアプリ画面の内容を非表示にする（リリースビルドのみ有効）
+        if (!BuildConfig.DEBUG) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
 
         setContent {
             App()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/RamenNoteDatabase.common.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/RamenNoteDatabase.common.kt
@@ -13,7 +13,7 @@ import dev.seabat.ramennote.data.database.entity.ShopEntity
 
 @Database(
     entities = [AreaEntity::class, ShopEntity::class, ReportEntity::class],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @ConstructedBy(RamenNoteDatabaseConstructor::class)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/AreaDao.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/AreaDao.kt
@@ -20,6 +20,9 @@ interface AreaDao {
     @Query("SELECT * FROM areas WHERE name = :name")
     suspend fun getAreaByName(name: String): AreaEntity?
 
+    @Query("SELECT * FROM areas WHERE areaId = :areaId")
+    suspend fun getAreaById(areaId: Int): AreaEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertArea(area: AreaEntity)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ReportDao.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ReportDao.kt
@@ -27,6 +27,9 @@ interface ReportDao {
     @Query("DELETE FROM reports WHERE id = :id")
     suspend fun deleteById(id: Int)
 
+    @Query("DELETE FROM reports WHERE shopId = :shopId")
+    suspend fun deleteByShopId(shopId: Int)
+
     @Query("SELECT * FROM reports WHERE areaId = :areaId ORDER BY date DESC")
     suspend fun getReportsByAreaId(areaId: Int): List<ReportEntity>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ReportDao.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ReportDao.kt
@@ -26,4 +26,7 @@ interface ReportDao {
 
     @Query("DELETE FROM reports WHERE id = :id")
     suspend fun deleteById(id: Int)
+
+    @Query("SELECT * FROM reports WHERE areaId = :areaId ORDER BY date DESC")
+    suspend fun getReportsByAreaId(areaId: Int): List<ReportEntity>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ShopDao.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ShopDao.kt
@@ -20,8 +20,8 @@ interface ShopDao {
     @Query("SELECT * FROM shops WHERE id = :id")
     suspend fun getShopById(id: Int): ShopEntity?
 
-    @Query("SELECT * FROM shops WHERE area = :area")
-    suspend fun getShopsByArea(area: String): List<ShopEntity>
+    @Query("SELECT * FROM shops WHERE areaId = :areaId")
+    suspend fun getShopsByAreaId(areaId: Int): List<ShopEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertShop(shop: ShopEntity)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/AreaEntity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/AreaEntity.kt
@@ -1,19 +1,24 @@
 package dev.seabat.ramennote.data.database.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
  * AreaEntity
  *
- * @property name
+ * @property areaId 自動採番の主キー
+ * @property name エリア名（一意インデックス）
  * @property count
  * @property date ISO8601 format string
  * @property sort UI上の順序を意味するカラム
  */
-@Entity(tableName = "areas")
+@Entity(
+    tableName = "areas",
+    indices = [Index(value = ["name"], unique = true)]
+)
 data class AreaEntity(
-    @PrimaryKey
+    @PrimaryKey(autoGenerate = true) val areaId: Int = 0,
     val name: String,
     val count: Int,
     val date: String,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ReportEntity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ReportEntity.kt
@@ -12,5 +12,6 @@ data class ReportEntity(
     val photoName: String,
     val impression: String,
     val date: String, // ISO8601 format string (yyyy-MM-dd)
-    val star: Int
+    val star: Int,
+    val areaId: Int = 0
 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ShopEntity.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/database/entity/ShopEntity.kt
@@ -8,7 +8,7 @@ data class ShopEntity(
     @PrimaryKey
     val id: Int,
     val name: String,
-    val area: String,
+    val areaId: Int,
     val shopUrl: String,
     val mapUrl: String,
     val star: Int,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
@@ -47,7 +47,7 @@ expect val factoryModule: Module
 val repositoryModule =
     module {
         single<AppVersionRepositoryContract> { AppVersionRepository() }
-        single<AreasRepositoryContract> { AreasRepository(get()) }
+        single<AreasRepositoryContract> { get<RamenNoteDatabase>().let { db -> AreasRepository(db.areaDao(), db) } }
         single<AreaImageRepositoryContract> {
             AreaImageRepository(
                 HttpClient {
@@ -97,6 +97,94 @@ val MIGRATION_4_5 =
         }
     }
 
+/**
+ * データベースバージョンを 5 から 6 にマイグレーションする
+ *
+ * - areas テーブル: name を PK から外し、areaId（AUTOINCREMENT）を PK に変更
+ * - shops テーブル: area（String）を areaId（Int）に変更
+ * - reports テーブル: areaId カラムを追加
+ */
+val MIGRATION_5_6 =
+    object : Migration(5, 6) {
+        override fun migrate(connection: SQLiteConnection) {
+            // areas テーブルを再作成（areaId を PK、name を UNIQUE INDEX）
+            connection.execSQL(
+                """
+                CREATE TABLE areas_new (
+                    areaId INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    name TEXT NOT NULL,
+                    count INTEGER NOT NULL,
+                    date TEXT NOT NULL,
+                    sort INTEGER NOT NULL DEFAULT 1
+                )
+                """.trimIndent()
+            )
+            connection.execSQL(
+                """
+                INSERT INTO areas_new (name, count, date, sort)
+                    SELECT name, count, date, sort FROM areas ORDER BY sort
+                """.trimIndent()
+            )
+            connection.execSQL("DROP TABLE areas")
+            connection.execSQL("ALTER TABLE areas_new RENAME TO areas")
+            connection.execSQL("CREATE UNIQUE INDEX index_areas_name ON areas (name)")
+
+            // shops テーブルを再作成（area String → areaId Int）
+            connection.execSQL(
+                """
+                CREATE TABLE shops_new (
+                    id INTEGER PRIMARY KEY NOT NULL,
+                    name TEXT NOT NULL DEFAULT '',
+                    areaId INTEGER NOT NULL DEFAULT 0,
+                    shopUrl TEXT NOT NULL DEFAULT '',
+                    mapUrl TEXT NOT NULL DEFAULT '',
+                    star INTEGER NOT NULL DEFAULT 0,
+                    stationName TEXT NOT NULL DEFAULT '',
+                    category TEXT NOT NULL DEFAULT '',
+                    scheduledDate TEXT NOT NULL DEFAULT '',
+                    menuName1 TEXT NOT NULL DEFAULT '',
+                    menuName2 TEXT NOT NULL DEFAULT '',
+                    menuName3 TEXT NOT NULL DEFAULT '',
+                    photoName1 TEXT NOT NULL DEFAULT '',
+                    photoName2 TEXT NOT NULL DEFAULT '',
+                    photoName3 TEXT NOT NULL DEFAULT '',
+                    description1 TEXT NOT NULL DEFAULT '',
+                    description2 TEXT NOT NULL DEFAULT '',
+                    description3 TEXT NOT NULL DEFAULT '',
+                    favorite INTEGER NOT NULL DEFAULT 0,
+                    note TEXT NOT NULL DEFAULT ''
+                )
+                """.trimIndent()
+            )
+            connection.execSQL(
+                """
+                INSERT INTO shops_new
+                    SELECT s.id, s.name, COALESCE(a.areaId, 0), s.shopUrl, s.mapUrl, s.star,
+                           s.stationName, s.category, s.scheduledDate,
+                           s.menuName1, s.menuName2, s.menuName3,
+                           s.photoName1, s.photoName2, s.photoName3,
+                           s.description1, s.description2, s.description3,
+                           s.favorite, s.note
+                    FROM shops s LEFT JOIN areas a ON s.area = a.name
+                """.trimIndent()
+            )
+            connection.execSQL("DROP TABLE shops")
+            connection.execSQL("ALTER TABLE shops_new RENAME TO shops")
+
+            // reports テーブルに areaId カラムを追加し、shops から補完
+            connection.execSQL(
+                "ALTER TABLE reports ADD COLUMN areaId INTEGER NOT NULL DEFAULT 0"
+            )
+            connection.execSQL(
+                """
+                UPDATE reports SET areaId = (
+                    SELECT COALESCE(areaId, 0) FROM shops WHERE shops.id = reports.shopId
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
 fun getRamenNoteDatabase(
     factory: DatabaseFactoryContract
 ): RamenNoteDatabase =
@@ -104,5 +192,5 @@ fun getRamenNoteDatabase(
         .getBuilder()
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
-        .addMigrations(MIGRATION_3_4, MIGRATION_4_5)
+        .addMigrations(MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
         .build()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepository.kt
@@ -11,32 +11,23 @@ import kotlinx.datetime.LocalDate
 import kotlin.lazy
 
 class AreasRepository(
+    private val areaDao: AreaDao,
     private val database: RamenNoteDatabase
 ) : AreasRepositoryContract {
-    private val areaDao: AreaDao by lazy {
-        database.areaDao()
-    }
 
     override suspend fun load(): List<Area> {
         val entities = areaDao.getAllAreas()
-        return entities.map { entity ->
-            Area(
-                name = entity.name,
-                updatedDate = LocalDate.parse(entity.date),
-                count = entity.count,
-                sort = entity.sort
-            )
-        }
+        return entities.map { entity -> entity.toDomain() }
     }
 
     override suspend fun load(areaName: String): Area? {
         val entity = areaDao.getAreaByName(areaName) ?: return null
-        return Area(
-            name = entity.name,
-            updatedDate = LocalDate.parse(entity.date),
-            count = entity.count,
-            sort = entity.sort
-        )
+        return entity.toDomain()
+    }
+
+    override suspend fun loadByAreaId(areaId: Int): Area? {
+        val entity = areaDao.getAreaById(areaId) ?: return null
+        return entity.toDomain()
     }
 
     override suspend fun add(area: Area) {
@@ -54,14 +45,9 @@ class AreasRepository(
     override suspend fun edit(oldName: String, newName: String): RunStatus<String> {
         val existingEntity = areaDao.getAreaByName(oldName)
         if (existingEntity != null) {
-            // 主キー（name）を変更する場合は、トランザクション内で削除と挿入を実行
-            database.useWriterConnection { transactor ->
-                transactor.immediateTransaction {
-                    val updatedEntity = existingEntity.copy(name = newName)
-                    areaDao.deleteArea(existingEntity)
-                    areaDao.insertArea(updatedEntity)
-                }
-            }
+            // areaId が PK になったため、name のみ UPDATE すればよい
+            val updatedEntity = existingEntity.copy(name = newName)
+            areaDao.updateArea(updatedEntity)
             return RunStatus.Success(data = "")
         }
         return RunStatus.Error(errorMessage = "${oldName}は登録されていません。編集に失敗しました")
@@ -115,3 +101,12 @@ class AreasRepository(
         return RunStatus.Error(errorMessage = "${areaName}は登録されていません。削除に失敗しました")
     }
 }
+
+private fun AreaEntity.toDomain(): Area =
+    Area(
+        areaId = areaId,
+        name = name,
+        updatedDate = LocalDate.parse(date),
+        count = count,
+        sort = sort
+    )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepository.kt
@@ -8,13 +8,11 @@ import dev.seabat.ramennote.data.database.entity.AreaEntity
 import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import kotlinx.datetime.LocalDate
-import kotlin.lazy
 
 class AreasRepository(
     private val areaDao: AreaDao,
     private val database: RamenNoteDatabase
 ) : AreasRepositoryContract {
-
     override suspend fun load(): List<Area> {
         val entities = areaDao.getAllAreas()
         return entities.map { entity -> entity.toDomain() }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryContract.kt
@@ -16,5 +16,7 @@ interface AreasRepositoryContract {
 
     suspend fun editAll(areas: List<Area>): RunStatus<String>
 
+    suspend fun loadByAreaId(areaId: Int): Area?
+
     suspend fun delete(areaName: String): RunStatus<String>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepository.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.withContext
 class LocalImageRepository(
     private val localStorageDataSource: LocalStorageDataSourceContract
 ) : LocalImageRepositoryContract {
-
     override suspend fun save(imageBytes: ByteArray, name: String) {
         withContext(Dispatchers.IO) {
             localStorageDataSource.save(imageBytes, name)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepository.kt
@@ -27,6 +27,10 @@ class ReportsRepository(
         reportDao.deleteById(id)
     }
 
+    override suspend fun deleteByShopId(shopId: Int) {
+        reportDao.deleteByShopId(shopId)
+    }
+
     override suspend fun loadByAreaId(areaId: Int): List<Report> =
         reportDao.getReportsByAreaId(areaId).map { it.toDomain() }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepository.kt
@@ -26,6 +26,9 @@ class ReportsRepository(
     override suspend fun delete(id: Int) {
         reportDao.deleteById(id)
     }
+
+    override suspend fun loadByAreaId(areaId: Int): List<Report> =
+        reportDao.getReportsByAreaId(areaId).map { it.toDomain() }
 }
 
 private fun ReportEntity.toDomain(): Report =
@@ -36,7 +39,8 @@ private fun ReportEntity.toDomain(): Report =
         photoName = photoName,
         impression = impression,
         date = if (date.isEmpty()) null else LocalDate.parse(date),
-        star = star
+        star = star,
+        areaId = areaId
     )
 
 private fun Report.toEntity(): ReportEntity =
@@ -47,5 +51,6 @@ private fun Report.toEntity(): ReportEntity =
         photoName = photoName,
         impression = impression,
         date = date?.toString() ?: "",
-        star = star
+        star = star,
+        areaId = areaId
     )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepositoryContract.kt
@@ -13,5 +13,7 @@ interface ReportsRepositoryContract {
 
     suspend fun delete(id: Int)
 
+    suspend fun deleteByShopId(shopId: Int)
+
     suspend fun loadByAreaId(areaId: Int): List<Report>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ReportsRepositoryContract.kt
@@ -12,4 +12,6 @@ interface ReportsRepositoryContract {
     suspend fun update(report: Report)
 
     suspend fun delete(id: Int)
+
+    suspend fun loadByAreaId(areaId: Int): List<Report>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
@@ -27,7 +27,7 @@ class ShopsRepository(
 
     override suspend fun getShopById(id: Int): Shop? = shopDao.getShopById(id)?.toDomainModel()
 
-    override suspend fun getShopsByArea(area: String): List<Shop> = shopDao.getShopsByArea(area).map { it.toDomainModel() }
+    override suspend fun getShopsByAreaId(areaId: Int): List<Shop> = shopDao.getShopsByAreaId(areaId).map { it.toDomainModel() }
 
     override suspend fun insertShop(shop: Shop) {
         shopDao.insertShop(shop.toEntity())
@@ -52,7 +52,7 @@ private fun ShopEntity.toDomainModel(): Shop =
     Shop(
         id = id,
         name = name,
-        area = area,
+        areaId = areaId,
         shopUrl = shopUrl,
         mapUrl = mapUrl,
         star = star,
@@ -76,7 +76,7 @@ private fun Shop.toEntity(): ShopEntity =
     ShopEntity(
         id = id,
         name = name,
-        area = area,
+        areaId = areaId,
         shopUrl = shopUrl,
         mapUrl = mapUrl,
         star = star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryContract.kt
@@ -10,7 +10,7 @@ interface ShopsRepositoryContract {
 
     suspend fun getShopById(id: Int): Shop?
 
-    suspend fun getShopsByArea(area: String): List<Shop>
+    suspend fun getShopsByAreaId(areaId: Int): List<Shop>
 
     suspend fun insertShop(shop: Shop)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepository.kt
@@ -3,8 +3,8 @@ package dev.seabat.ramennote.data.repository
 import dev.seabat.ramennote.config.UnsplashConfig
 import dev.seabat.ramennote.domain.model.RunStatus
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.request.parameter
@@ -46,12 +46,13 @@ class UnsplashImageRepository(
         }
 }
 
-private fun toErrorMessage(e: Throwable): String = when {
-    e is HttpRequestTimeoutException -> "通信がタイムアウトしました"
-    e.message?.contains("timeout", ignoreCase = true) == true -> "通信がタイムアウトしました"
-    e.cause?.message?.contains("timeout", ignoreCase = true) == true -> "通信がタイムアウトしました"
-    else -> e.message ?: "画像の取得に失敗しました"
-}
+private fun toErrorMessage(e: Throwable): String =
+    when {
+        e is HttpRequestTimeoutException -> "通信がタイムアウトしました"
+        e.message?.contains("timeout", ignoreCase = true) == true -> "通信がタイムアウトしました"
+        e.cause?.message?.contains("timeout", ignoreCase = true) == true -> "通信がタイムアウトしました"
+        else -> e.message ?: "画像の取得に失敗しました"
+    }
 
 @Serializable
 data class UnsplashSearchResponse(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepositoryContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.data.repository
 import dev.seabat.ramennote.domain.model.RunStatus
 
 interface UnsplashImageRepositoryContract {
-    suspend fun fetch(query: String):  RunStatus<ByteArray>
+    suspend fun fetch(query: String): RunStatus<ByteArray>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -26,6 +26,8 @@ import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCase
 import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.InquiryAppVersionUseCase
 import dev.seabat.ramennote.domain.usecase.InquiryAppVersionUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreaImageUseCase
+import dev.seabat.ramennote.domain.usecase.LoadAreaImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadAreasUseCase
 import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFavoriteShopsUseCase
@@ -90,7 +92,7 @@ val useCaseModule =
         single<FetchAndSaveUnsplashImageUseCaseContract> { FetchAndSaveUnsplashImageUseCase(get(), get()) }
         single<InquiryAppVersionUseCaseContract> { InquiryAppVersionUseCase(get()) }
         single<LoadAreasUseCaseContract> { LoadAreasUseCase(get()) }
-        single<LoadImageUseCaseContract> { LoadImageUseCase(get()) }
+        single<LoadAreaImageUseCaseContract> { LoadAreaImageUseCase(get(), get()) }
         single<LoadImageUseCaseContract> { LoadImageUseCase(get()) }
         single<LoadShopListByAreaUseCaseContract> { LoadShopListByAreaUseCase(get(), get()) }
         single<LoadShopUseCaseContract> { LoadShopUseCase(get()) }
@@ -113,7 +115,7 @@ val useCaseModule =
         single<SearchShopsByNameUseCaseContract> { SearchShopsByNameUseCase(get()) }
         single<SwitchFavoriteUseCaseContract> { SwitchFavoriteUseCase(get()) }
         single<UpdateAreaImageUseCaseContract> { UpdateAreaImageUseCase(get(), get(), get()) }
-        single<UpdateAreaUseCaseContract> { UpdateAreaUseCase(get(), get(), get()) }
+        single<UpdateAreaUseCaseContract> { UpdateAreaUseCase(get(), get()) }
         single<UpdateShopCountInAreaUseCaseContract> { UpdateShopCountInAreaUseCase(get(), get()) }
         single<UpdateShopUseCaseContract> { UpdateShopUseCase(get(), get(), get()) }
         single<UpdateAllAreasUseCaseContract> { UpdateAllAreasUseCase(get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -86,7 +86,7 @@ val useCaseModule =
         single<DeleteAreaUseCaseContract> { DeleteAreaUseCase(get(), get(), get()) }
         single<DeleteReportUseCaseContract> { DeleteReportUseCase(get()) }
         single<DeleteScheduleInShopUseCaseContract> { DeleteScheduleInShopUseCase(get()) }
-        single<DeleteShopAndImageUseCaseContract> { DeleteShopAndImageUseCase(get(), get(), get()) }
+        single<DeleteShopAndImageUseCaseContract> { DeleteShopAndImageUseCase(get(), get(), get(), get()) }
         single<FetchAiShopUseCaseContract> { FetchAiShopInfoUseCase(get(), get()) }
         single<FetchPlaceHolderImageUseCaseContract> { FetchPlaceHolderImageUseCase(get(), get()) }
         single<FetchAndSaveUnsplashImageUseCaseContract> { FetchAndSaveUnsplashImageUseCase(get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -83,7 +83,7 @@ val useCaseModule =
         single<CreateNoImageByteArrayUseCaseContract> { CreateNoImageByteArrayUseCase(get()) }
         single<CreateNoImageIfNeededUseCaseContract> { CreateNoImageIfNeededUseCase(get(), get()) }
         single<CreateReportPhotoNameUseCaseContract> { CreateReportPhotoNameUseCase() }
-        single<DeleteAreaUseCaseContract> { DeleteAreaUseCase(get(), get(), get()) }
+        single<DeleteAreaUseCaseContract> { DeleteAreaUseCase(get(), get()) }
         single<DeleteReportUseCaseContract> { DeleteReportUseCase(get()) }
         single<DeleteScheduleInShopUseCaseContract> { DeleteScheduleInShopUseCase(get()) }
         single<DeleteShopAndImageUseCaseContract> { DeleteShopAndImageUseCase(get(), get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -20,10 +20,10 @@ import dev.seabat.ramennote.domain.usecase.DeleteShopAndImageUseCase
 import dev.seabat.ramennote.domain.usecase.DeleteShopAndImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchAiShopInfoUseCase
 import dev.seabat.ramennote.domain.usecase.FetchAiShopUseCaseContract
-import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCase
-import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCase
 import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCase
+import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.InquiryAppVersionUseCase
 import dev.seabat.ramennote.domain.usecase.InquiryAppVersionUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadAreasUseCase
@@ -32,6 +32,10 @@ import dev.seabat.ramennote.domain.usecase.LoadFavoriteShopsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadFavoriteShopsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportUseCase
 import dev.seabat.ramennote.domain.usecase.LoadFullReportUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByAreaUseCase
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByAreaUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByShopUseCase
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCase
@@ -88,11 +92,13 @@ val useCaseModule =
         single<LoadAreasUseCaseContract> { LoadAreasUseCase(get()) }
         single<LoadImageUseCaseContract> { LoadImageUseCase(get()) }
         single<LoadImageUseCaseContract> { LoadImageUseCase(get()) }
-        single<LoadShopListByAreaUseCaseContract> { LoadShopListByAreaUseCase(get()) }
+        single<LoadShopListByAreaUseCaseContract> { LoadShopListByAreaUseCase(get(), get()) }
         single<LoadShopUseCaseContract> { LoadShopUseCase(get()) }
         single<LoadRecentScheduleUseCaseContract> { LoadRecentScheduleUseCase(get(), get()) }
         single<LoadFullReportUseCaseContract> { LoadFullReportUseCase(get(), get(), get()) }
         single<LoadFullReportsUseCaseContract> { LoadFullReportsUseCase(get(), get(), get()) }
+        single<LoadFullReportsByShopUseCaseContract> { LoadFullReportsByShopUseCase(get(), get(), get()) }
+        single<LoadFullReportsByAreaUseCaseContract> { LoadFullReportsByAreaUseCase(get(), get(), get()) }
         single<LoadThreeMonthsFullReportsUseCaseContract> {
             LoadThreeMonthsFullReportsUseCase(
                 get(),

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Area.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Area.kt
@@ -11,6 +11,7 @@ import kotlinx.datetime.LocalDate
  * @property sort UI上の順序を意味する。追加の際は Repository で自動採番する。
  */
 data class Area(
+    val areaId: Int = 0,
     val name: String,
     val updatedDate: LocalDate,
     val count: Int,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/FullReport.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/FullReport.kt
@@ -12,5 +12,6 @@ data class FullReport(
     val impression: String = "",
     val date: LocalDate = createTodayLocalDate(),
     val imageBytes: ByteArray? = null,
-    val star: Int = 0
+    val star: Int = 0,
+    val areaId: Int = 0
 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Report.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Report.kt
@@ -10,7 +10,8 @@ data class Report(
     val photoName: String = "",
     val impression: String = "",
     val date: LocalDate? = null,
-    val star: Int = 0
+    val star: Int = 0,
+    val areaId: Int = 0
 ) {
     fun toJsonString(): String = Json.encodeToString(this)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Shop.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/Shop.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.Json
 data class Shop(
     val id: Int = 0,
     val name: String = "",
-    val area: String = "",
+    val areaId: Int = 0,
     val shopUrl: String = "",
     val mapUrl: String = "",
     val star: Int = 0,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddShopUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddShopUseCase.kt
@@ -24,6 +24,6 @@ class AddShopUseCase(
         shopsRepository.insertShop(shopWithId)
 
         // エリア件数更新
-        updateShopCountInAreaUseCase(shop.area)
+        updateShopCountInAreaUseCase(shopWithId.areaId)
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
@@ -18,7 +18,9 @@ class DeleteAreaUseCase(
                 localAreaImageRepository.delete(name)
 
                 // 該当エリアのShopを削除
-                val shops = shopsRepository.getShopsByArea(name)
+                val area = areasRepository.load(name)
+                val areaId = area?.areaId ?: 0
+                val shops = shopsRepository.getShopsByAreaId(areaId)
                 shops.forEach { shop ->
                     shopsRepository.deleteShopById(shop.id)
                 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
@@ -11,6 +11,9 @@ class DeleteAreaUseCase(
     private val shopsRepository: ShopsRepositoryContract
 ) : DeleteAreaUseCaseContract {
     override suspend operator fun invoke(name: String): RunStatus<String> {
+        // 削除前に areaId を取得（削除後は load() が null を返すため）
+        val areaId = areasRepository.load(name)?.areaId ?: 0
+
         val result = areasRepository.delete(name)
         return if (result is RunStatus.Success) {
             try {
@@ -18,8 +21,6 @@ class DeleteAreaUseCase(
                 localAreaImageRepository.delete(name)
 
                 // 該当エリアのShopを削除
-                val area = areasRepository.load(name)
-                val areaId = area?.areaId ?: 0
                 val shops = shopsRepository.getShopsByAreaId(areaId)
                 shops.forEach { shop ->
                     shopsRepository.deleteShopById(shop.id)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
@@ -2,31 +2,29 @@ package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
-import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 
 class DeleteAreaUseCase(
     private val areasRepository: AreasRepositoryContract,
-    private val localAreaImageRepository: LocalImageRepositoryContract,
-    private val shopsRepository: ShopsRepositoryContract
+    private val localAreaImageRepository: LocalImageRepositoryContract
 ) : DeleteAreaUseCaseContract {
     override suspend operator fun invoke(areaId: Int): RunStatus<String> {
-        // 削除前に エリア名を取得（削除後は loadByAreaId() が null を返すため）
-        val name =
-            areasRepository.loadByAreaId(areaId)?.name
+        // 削除前に エリアを取得（削除後は loadByAreaId() が null を返すため）
+        val area =
+            areasRepository.loadByAreaId(areaId)
                 ?: return RunStatus.Error("エリアが見つかりません")
+
+        if (area.count >= 1) {
+            return RunStatus.Error("エリアを削除する前にエリアに登録しているお店を全て削除してください。")
+        }
+
+        val name = area.name
 
         val result = areasRepository.delete(name)
         return if (result is RunStatus.Success) {
             try {
                 // エリア画像の削除
                 localAreaImageRepository.delete(name)
-
-                // 該当エリアのShopを削除
-                val shops = shopsRepository.getShopsByAreaId(areaId)
-                shops.forEach { shop ->
-                    shopsRepository.deleteShopById(shop.id)
-                }
                 RunStatus.Success("")
             } catch (e: Exception) {
                 RunStatus.Error(e.message ?: "エリア削除後の関連データ削除に失敗しました")

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCase.kt
@@ -10,9 +10,11 @@ class DeleteAreaUseCase(
     private val localAreaImageRepository: LocalImageRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract
 ) : DeleteAreaUseCaseContract {
-    override suspend operator fun invoke(name: String): RunStatus<String> {
-        // 削除前に areaId を取得（削除後は load() が null を返すため）
-        val areaId = areasRepository.load(name)?.areaId ?: 0
+    override suspend operator fun invoke(areaId: Int): RunStatus<String> {
+        // 削除前に エリア名を取得（削除後は loadByAreaId() が null を返すため）
+        val name =
+            areasRepository.loadByAreaId(areaId)?.name
+                ?: return RunStatus.Error("エリアが見つかりません")
 
         val result = areasRepository.delete(name)
         return if (result is RunStatus.Success) {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteAreaUseCaseContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.RunStatus
 
 interface DeleteAreaUseCaseContract {
-    suspend operator fun invoke(name: String): RunStatus<String>
+    suspend operator fun invoke(areaId: Int): RunStatus<String>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
@@ -1,19 +1,24 @@
 package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 
 class DeleteShopAndImageUseCase(
     private val shopsRepository: ShopsRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract,
-    private val updateShopCountInAreaUseCase: UpdateShopCountInAreaUseCaseContract
+    private val updateShopCountInAreaUseCase: UpdateShopCountInAreaUseCaseContract,
+    private val reportsRepository: ReportsRepositoryContract
 ) : DeleteShopAndImageUseCaseContract {
     override suspend operator fun invoke(shopId: Int): RunStatus<String> =
         try {
             // Shopデータを取得して画像名を確認
             val shop = shopsRepository.getShopById(shopId)
             if (shop != null) {
+                // 関連するレポートを削除
+                deleteReportsByShopId(shopId)
+
                 // Shopデータを削除
                 shopsRepository.deleteShopById(shopId)
 
@@ -33,6 +38,10 @@ class DeleteShopAndImageUseCase(
         } catch (e: Exception) {
             RunStatus.Error(errorMessage = "削除に失敗しました: ${e.message}")
         }
+
+    private suspend fun deleteReportsByShopId(shopId: Int) {
+        reportsRepository.deleteByShopId(shopId)
+    }
 
     private suspend fun updateShopCount(shopId: Int) {
         // 削除前にエリア ID を取得

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
@@ -13,7 +13,7 @@ class DeleteShopAndImageUseCase(
 ) : DeleteShopAndImageUseCaseContract {
     override suspend operator fun invoke(shopId: Int): RunStatus<String> =
         try {
-            // Shopデータを取得して画像名を確認
+            // Shopデータを取得して画像名とエリアIDを確認（削除前に取得する）
             val shop = shopsRepository.getShopById(shopId)
             if (shop != null) {
                 // 関連するレポートを削除
@@ -32,8 +32,12 @@ class DeleteShopAndImageUseCase(
                 if (shop.photoName3.isNotEmpty()) {
                     localAreaImageRepository.delete(shop.photoName3)
                 }
+
+                // 削除したshopのエリアIDでエリア件数を更新する
+                if (shop.areaId != 0) {
+                    updateShopCountInAreaUseCase(shop.areaId)
+                }
             }
-            updateShopCount(shopId)
             RunStatus.Success(data = "削除が完了しました")
         } catch (e: Exception) {
             RunStatus.Error(errorMessage = "削除に失敗しました: ${e.message}")
@@ -41,16 +45,5 @@ class DeleteShopAndImageUseCase(
 
     private suspend fun deleteReportsByShopId(shopId: Int) {
         reportsRepository.deleteByShopId(shopId)
-    }
-
-    private suspend fun updateShopCount(shopId: Int) {
-        // 削除前にエリア ID を取得
-        val shop = shopsRepository.getShopById(shopId)
-        val areaId = shop?.areaId
-
-        // 削除成功時にエリア件数を更新する
-        if (areaId != null && areaId != 0) {
-            updateShopCountInAreaUseCase(areaId)
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCase.kt
@@ -35,13 +35,13 @@ class DeleteShopAndImageUseCase(
         }
 
     private suspend fun updateShopCount(shopId: Int) {
-        // 削除前にエリア名を取得
+        // 削除前にエリア ID を取得
         val shop = shopsRepository.getShopById(shopId)
-        val areaName = shop?.area
+        val areaId = shop?.areaId
 
         // 削除成功時にエリア件数を更新する
-        if (!areaName.isNullOrEmpty()) {
-            updateShopCountInAreaUseCase(areaName)
+        if (areaId != null && areaId != 0) {
+            updateShopCountInAreaUseCase(areaId)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchAndSaveUnsplashImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchAndSaveUnsplashImageUseCase.kt
@@ -15,10 +15,9 @@ class FetchAndSaveUnsplashImageUseCase(
     private val unsplashImageRepository: UnsplashImageRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract
 ) : FetchAndSaveUnsplashImageUseCaseContract {
-
     override suspend operator fun invoke(query: String): RunStatus<ByteArray> {
         // Fetch image from remote repository
-        return when(val fetchResult = unsplashImageRepository.fetch(query)) {
+        return when (val fetchResult = unsplashImageRepository.fetch(query)) {
             is RunStatus.Error -> {
                 return fetchResult
             }
@@ -28,14 +27,14 @@ class FetchAndSaveUnsplashImageUseCase(
                 localAreaImageRepository.save(imageBytes, query)
 
                 // Load from local storage with query as filename
-                when(val localImageBytes = localAreaImageRepository.load(query)) {
+                when (val localImageBytes = localAreaImageRepository.load(query)) {
                     is RunStatus.Success -> localImageBytes
                     is RunStatus.Error -> RunStatus.Error("Failed to load image from local storage")
                     else -> error("unexpected state")
                 }
             }
             else -> {
-               error("ここは通らない")
+                error("ここは通らない")
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchPlaceHolderImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchPlaceHolderImageUseCase.kt
@@ -8,7 +8,6 @@ class FetchPlaceHolderImageUseCase(
     private val areaImageRepository: AreaImageRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract
 ) : FetchPlaceHolderImageUseCaseContract {
-
     override suspend operator fun invoke(): RunStatus<ByteArray> =
         try {
             // Fetch image from remote repository

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadAreaImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadAreaImageUseCase.kt
@@ -1,0 +1,17 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.domain.model.RunStatus
+
+class LoadAreaImageUseCase(
+    private val areasRepository: AreasRepositoryContract,
+    private val localAreaImageRepository: LocalImageRepositoryContract
+) : LoadAreaImageUseCaseContract {
+    override suspend operator fun invoke(areaId: Int): RunStatus<ByteArray> {
+        val areaName =
+            areasRepository.loadByAreaId(areaId)?.name
+                ?: return RunStatus.Error("エリアが見つかりません")
+        return localAreaImageRepository.load(areaName)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadAreaImageUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadAreaImageUseCaseContract.kt
@@ -2,6 +2,6 @@ package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.domain.model.RunStatus
 
-interface UpdateAreaImageUseCaseContract {
+interface LoadAreaImageUseCaseContract {
     suspend operator fun invoke(areaId: Int): RunStatus<ByteArray>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
@@ -11,7 +11,6 @@ class LoadFullReportUseCase(
     private val shopsRepository: ShopsRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract
 ) : LoadFullReportUseCaseContract {
-
     override suspend operator fun invoke(reportId: Int): FullReport? {
         val report = reportsRepository.loadById(reportId) ?: return null
         val shop = shopsRepository.getShopById(report.shopId)
@@ -23,11 +22,12 @@ class LoadFullReportUseCase(
             shopName = shop?.name ?: "不明な店舗",
             menuName = report.menuName,
             photoName = report.photoName,
-            imageBytes = when(imageBytes) {
-                is RunStatus.Success -> imageBytes.data
-                is RunStatus.Error -> return null
-                else -> error("unexpected state")
-            },
+            imageBytes =
+                when (imageBytes) {
+                    is RunStatus.Success -> imageBytes.data
+                    is RunStatus.Error -> return null
+                    else -> error("unexpected state")
+                },
             impression = report.impression,
             date = report.date!!,
             star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
@@ -30,7 +30,8 @@ class LoadFullReportUseCase(
             },
             impression = report.impression,
             date = report.date!!,
-            star = report.star
+            star = report.star,
+            areaId = report.areaId
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
@@ -1,0 +1,41 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.FullReport
+import dev.seabat.ramennote.domain.model.RunStatus
+
+class LoadFullReportsByAreaUseCase(
+    private val reportsRepository: ReportsRepositoryContract,
+    private val shopsRepository: ShopsRepositoryContract,
+    private val localImageRepository: LocalImageRepositoryContract
+) : LoadFullReportsByAreaUseCaseContract {
+    override suspend operator fun invoke(areaId: Int): List<FullReport> {
+        val reports = reportsRepository.loadByAreaId(areaId)
+
+        return reports.map { report ->
+            val shop = shopsRepository.getShopById(report.shopId)
+            val imageBytes = localImageRepository.load(report.photoName)
+            FullReport(
+                id = report.id,
+                shopId = report.shopId,
+                shopName = shop?.name ?: "不明な店舗",
+                menuName = report.menuName,
+                photoName = report.photoName,
+                imageBytes =
+                    when (imageBytes) {
+                        is RunStatus.Success ->
+                            imageBytes.data
+                        is RunStatus.Error ->
+                            null
+                        else -> error("unexpected state")
+                    },
+                impression = report.impression,
+                date = report.date!!,
+                star = report.star,
+                areaId = report.areaId
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCaseContract.kt
@@ -1,0 +1,10 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.FullReport
+
+/**
+ * 画像データを含めた食レポデータを areaId でフィルタリングして読み込む
+ */
+interface LoadFullReportsByAreaUseCaseContract {
+    suspend operator fun invoke(areaId: Int): List<FullReport>
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
@@ -1,0 +1,41 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.FullReport
+import dev.seabat.ramennote.domain.model.RunStatus
+
+class LoadFullReportsByShopUseCase(
+    private val reportsRepository: ReportsRepositoryContract,
+    private val shopsRepository: ShopsRepositoryContract,
+    private val localImageRepository: LocalImageRepositoryContract
+) : LoadFullReportsByShopUseCaseContract {
+    override suspend operator fun invoke(shopId: Int): List<FullReport> {
+        val reports = reportsRepository.load().filter { it.shopId == shopId }
+
+        return reports.map { report ->
+            val shop = shopsRepository.getShopById(report.shopId)
+            val imageBytes = localImageRepository.load(report.photoName)
+            FullReport(
+                id = report.id,
+                shopId = report.shopId,
+                shopName = shop?.name ?: "不明な店舗",
+                menuName = report.menuName,
+                photoName = report.photoName,
+                imageBytes =
+                    when (imageBytes) {
+                        is RunStatus.Success ->
+                            imageBytes.data
+                        is RunStatus.Error ->
+                            null
+                        else -> error("unexpected state")
+                    },
+                impression = report.impression,
+                date = report.date!!,
+                star = report.star,
+                areaId = report.areaId
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCaseContract.kt
@@ -1,0 +1,10 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.FullReport
+
+/**
+ * 画像データを含めた食レポデータを shopId でフィルタリングして読み込む
+ */
+interface LoadFullReportsByShopUseCaseContract {
+    suspend operator fun invoke(shopId: Int): List<FullReport>
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
@@ -11,32 +11,31 @@ class LoadFullReportsUseCase(
     private val shopsRepository: ShopsRepositoryContract,
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadFullReportsUseCaseContract {
-    override suspend operator fun invoke(shopId: Int?): List<FullReport> {
-        val reports =
-            reportsRepository
-                .load()
-                .filter { shopId == null || it.shopId == shopId }
+    override suspend operator fun invoke(): List<FullReport> {
+        val reports = reportsRepository.load()
 
         return reports.map { report ->
             val shop = shopsRepository.getShopById(report.shopId)
             val imageBytes = localImageRepository.load(report.photoName)
-                FullReport(
-                    id = report.id,
-                    shopId = report.shopId,
-                    shopName = shop?.name ?: "不明な店舗",
-                    menuName = report.menuName,
-                    photoName = report.photoName,
-                    imageBytes =  when (imageBytes) {
+            FullReport(
+                id = report.id,
+                shopId = report.shopId,
+                shopName = shop?.name ?: "不明な店舗",
+                menuName = report.menuName,
+                photoName = report.photoName,
+                imageBytes =
+                    when (imageBytes) {
                         is RunStatus.Success ->
                             imageBytes.data
                         is RunStatus.Error ->
                             null
                         else -> error("unexpected state")
                     },
-                    impression = report.impression,
-                    date = report.date!!,
-                    star = report.star
-                )
-            }
+                impression = report.impression,
+                date = report.date!!,
+                star = report.star,
+                areaId = report.areaId
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCaseContract.kt
@@ -3,12 +3,8 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.FullReport
 
 /**
- * 画像データを含めた食レポデータを読み込む
- *
- * - shopId が null の場合は全食レポをリターンする
- * - shopId が null でない場合は、食レポをを shopId でフィルタリングしてからリターンする
- *
+ * 画像データを含めた全食レポデータを読み込む
  */
 interface LoadFullReportsUseCaseContract {
-    suspend operator fun invoke(shopId: Int? = null): List<FullReport>
+    suspend operator fun invoke(): List<FullReport>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadImageUseCase.kt
@@ -6,6 +6,5 @@ import dev.seabat.ramennote.domain.model.RunStatus
 class LoadImageUseCase(
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadImageUseCaseContract {
-
     override suspend operator fun invoke(name: String): RunStatus<ByteArray> = localImageRepository.load(name)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaUseCase.kt
@@ -1,5 +1,6 @@
 package dev.seabat.ramennote.domain.usecase
 
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.Shop
 
@@ -9,10 +10,14 @@ import dev.seabat.ramennote.domain.model.Shop
  * - Shop.star の降順に並べる
  *
  * @property shopsRepository
+ * @property areasRepository
  */
 class LoadShopListByAreaUseCase(
-    private val shopsRepository: ShopsRepositoryContract
+    private val shopsRepository: ShopsRepositoryContract,
+    private val areasRepository: AreasRepositoryContract
 ) : LoadShopListByAreaUseCaseContract {
-    override suspend operator fun invoke(area: String): List<Shop> =
-        shopsRepository.getShopsByArea(area).sortedByDescending { it.star }
+    override suspend operator fun invoke(area: String): List<Shop> {
+        val areaEntity = areasRepository.load(area) ?: return emptyList()
+        return shopsRepository.getShopsByAreaId(areaEntity.areaId).sortedByDescending { it.star }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadThreeMonthsFullReportsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadThreeMonthsFullReportsUseCase.kt
@@ -52,7 +52,8 @@ class LoadThreeMonthsFullReportsUseCase(
                     },
                     impression = report.impression,
                     date = report.date!!,
-                    star = report.star
+                    star = report.star,
+                    areaId = report.areaId
                 )
             }.sortedByDescending { it.date }
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadThreeMonthsFullReportsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadThreeMonthsFullReportsUseCase.kt
@@ -45,11 +45,12 @@ class LoadThreeMonthsFullReportsUseCase(
                     shopName = shop?.name ?: "不明な店舗",
                     menuName = report.menuName,
                     photoName = report.photoName,
-                    imageBytes = when (photoData) {
-                        is RunStatus.Success -> photoData.data
-                        is RunStatus.Error -> null
-                        else -> error("unexpected state")
-                    },
+                    imageBytes =
+                        when (photoData) {
+                            is RunStatus.Success -> photoData.data
+                            is RunStatus.Error -> null
+                            else -> error("unexpected state")
+                        },
                     impression = report.impression,
                     date = report.date!!,
                     star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
@@ -11,16 +11,19 @@ class UpdateAreaImageUseCase(
     private val localAreaImageRepository: LocalImageRepositoryContract,
     private val fetchAndSaveUnsplashImageUseCaseContract: FetchAndSaveUnsplashImageUseCaseContract
 ) : UpdateAreaImageUseCaseContract {
+    override suspend operator fun invoke(areaId: Int): RunStatus<ByteArray> {
+        val areaData =
+            areasRepository.loadByAreaId(areaId)
+                ?: return RunStatus.Error("エリアが見つかりません")
+        val areaName = areaData.name
 
-    override suspend operator fun invoke(area: String): RunStatus<ByteArray> {
         // まずローカルから画像を読み込む。null なら必ず Unsplash から取得
-        localAreaImageRepository.load(area) ?: return fetchAndSaveUnsplashImageUseCaseContract(area)
+        localAreaImageRepository.load(areaName) ?: return fetchAndSaveUnsplashImageUseCaseContract(areaName)
 
-        val areaData = areasRepository.load(area)
         val today = createTodayLocalDate()
-        val needUpdate = areaData == null || areaData.updatedDate < today.minus(1, kotlinx.datetime.DateTimeUnit.DAY)
+        val needUpdate = areaData.updatedDate < today.minus(1, kotlinx.datetime.DateTimeUnit.DAY)
         return if (needUpdate) {
-            fetchAndSaveUnsplashImageUseCaseContract(area)
+            fetchAndSaveUnsplashImageUseCaseContract(areaName)
         } else {
             RunStatus.Error("本日は画像を変更できません。明日もう一度お試しください。")
         }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
@@ -2,15 +2,16 @@ package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
-import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 
 class UpdateAreaUseCase(
     private val areasRepository: AreasRepositoryContract,
-    private val localAreaImageRepository: LocalImageRepositoryContract,
-    private val shopsRepository: ShopsRepositoryContract
+    private val localAreaImageRepository: LocalImageRepositoryContract
 ) : UpdateAreaUseCaseContract {
-    override suspend fun invoke(oldName: String, newName: String): RunStatus<String> {
+    override suspend fun invoke(areaId: Int, newName: String): RunStatus<String> {
+        val oldName =
+            areasRepository.loadByAreaId(areaId)?.name
+                ?: return RunStatus.Error("エリアが見つかりません")
         val result = areasRepository.edit(oldName, newName)
         return if (result is RunStatus.Success) {
             try {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
@@ -17,12 +17,7 @@ class UpdateAreaUseCase(
                 // 画像名のリネーム
                 localAreaImageRepository.rename(oldName, newName)
 
-                // 該当エリアのShopを一括更新
-                val shops = shopsRepository.getShopsByArea(oldName)
-                shops.forEach { shop ->
-                    val updated = shop.copy(area = newName)
-                    shopsRepository.updateShop(updated)
-                }
+                // areaId が外部キーのため、エリア名変更時のShop更新は不要
                 RunStatus.Success("")
             } catch (e: Exception) {
                 RunStatus.Error("${e.message}")

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCaseContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.RunStatus
 
 interface UpdateAreaUseCaseContract {
-    suspend operator fun invoke(oldName: String, newName: String): RunStatus<String>
+    suspend operator fun invoke(areaId: Int, newName: String): RunStatus<String>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopCountInAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopCountInAreaUseCase.kt
@@ -8,10 +8,10 @@ class UpdateShopCountInAreaUseCase(
     private val areasRepository: AreasRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract
 ) : UpdateShopCountInAreaUseCaseContract {
-    override suspend operator fun invoke(area: String) {
-        val shops = shopsRepository.getShopsByArea(area)
+    override suspend operator fun invoke(areaId: Int) {
+        val shops = shopsRepository.getShopsByAreaId(areaId)
         val count = shops.size
-        val existing = areasRepository.load(area) ?: return
+        val existing = areasRepository.loadByAreaId(areaId) ?: return
         val nowDate = createTodayLocalDate()
         val updated = existing.copy(count = count, updatedDate = nowDate)
         areasRepository.edit(updated)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopCountInAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopCountInAreaUseCaseContract.kt
@@ -1,5 +1,5 @@
 package dev.seabat.ramennote.domain.usecase
 
 interface UpdateShopCountInAreaUseCaseContract {
-    suspend operator fun invoke(area: String)
+    suspend operator fun invoke(areaId: Int)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopUseCase.kt
@@ -9,14 +9,14 @@ class UpdateShopUseCase(
     private val localAreaImageRepository: LocalImageRepositoryContract,
     private val updateShopCountInAreaUseCase: UpdateShopCountInAreaUseCaseContract
 ) : UpdateShopUseCaseContract {
-    override suspend operator fun invoke(shop: Shop, byteArray: ByteArray?, oldArea: String) {
+    override suspend operator fun invoke(shop: Shop, byteArray: ByteArray?, oldAreaId: Int) {
         if (byteArray != null && shop.photoName1.isNotEmpty()) {
             localAreaImageRepository.save(byteArray, shop.photoName1)
         }
         shopsRepository.updateShop(shop)
 
         // エリアの変更が無くても店舗件数を更新
-        updateShopCountInAreaUseCase(oldArea)
-        updateShopCountInAreaUseCase(shop.area)
+        updateShopCountInAreaUseCase(oldAreaId)
+        updateShopCountInAreaUseCase(shop.areaId)
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateShopUseCaseContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.Shop
 
 interface UpdateShopUseCaseContract {
-    suspend operator fun invoke(shop: Shop, byteArray: ByteArray?, oldArea: String)
+    suspend operator fun invoke(shop: Shop, byteArray: ByteArray?, oldAreaId: Int)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddReportButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddReportButton.kt
@@ -1,0 +1,32 @@
+package dev.seabat.ramennote.ui.components.button
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.ramen_dining_24px
+import ramennote.composeapp.generated.resources.shop_menu_report_button
+
+@Composable
+fun AddReportButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ActionButton(
+        icon = vectorResource(Res.drawable.ramen_dining_24px),
+        text = stringResource(Res.string.shop_menu_report_button),
+        onClick = onClick,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun AddReportButtonPreview() {
+    RamenNoteTheme {
+        AddReportButton(onClick = {})
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/EditShopButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/EditShopButton.kt
@@ -1,0 +1,32 @@
+package dev.seabat.ramennote.ui.components.button
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.edit_24px
+import ramennote.composeapp.generated.resources.shop_menu_edit_button
+
+@Composable
+fun EditShopButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ActionButton(
+        icon = vectorResource(Res.drawable.edit_24px),
+        text = stringResource(Res.string.shop_menu_edit_button),
+        onClick = onClick,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun EditShopButtonPreview() {
+    RamenNoteTheme {
+        EditShopButton(onClick = {})
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
@@ -10,7 +10,6 @@ import ramennote.composeapp.generated.resources.Res
 import ramennote.composeapp.generated.resources.ramen_dining_24px
 import ramennote.composeapp.generated.resources.shop_menu_history_button
 
-
 @Composable
 fun ReportListButton(
     onClick: () -> Unit,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
@@ -1,0 +1,33 @@
+package dev.seabat.ramennote.ui.components.button
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.ramen_dining_24px
+import ramennote.composeapp.generated.resources.shop_menu_history_button
+
+
+@Composable
+fun ReportListButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ActionButton(
+        icon = vectorResource(Res.drawable.ramen_dining_24px),
+        text = stringResource(Res.string.shop_menu_history_button),
+        onClick = onClick,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun ReportListButtonPreview() {
+    RamenNoteTheme {
+        ReportListButton(onClick = {})
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ScheduleButton.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ScheduleButton.kt
@@ -1,0 +1,48 @@
+package dev.seabat.ramennote.ui.components.button
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.resources.vectorResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.event_note_24px
+import ramennote.composeapp.generated.resources.shop_menu_schedule_add_button
+import ramennote.composeapp.generated.resources.shop_menu_schedule_edit_button
+
+@Composable
+fun ScheduleButton(
+    hasScheduledDate: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val buttonText =
+        if (hasScheduledDate) {
+            stringResource(Res.string.shop_menu_schedule_edit_button)
+        } else {
+            stringResource(Res.string.shop_menu_schedule_add_button)
+        }
+    ActionButton(
+        icon = vectorResource(Res.drawable.event_note_24px),
+        text = buttonText,
+        onClick = onClick,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun ScheduleButtonAddPreview() {
+    RamenNoteTheme {
+        ScheduleButton(hasScheduledDate = false, onClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun ScheduleButtonEditPreview() {
+    RamenNoteTheme {
+        ScheduleButton(hasScheduledDate = true, onClick = {})
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
@@ -22,7 +22,7 @@ val viewModelModule =
         viewModel { AddAreaViewModel(get(), get()) }
         viewModel { AddShopViewModel(get(), get(), get(), get()) }
         viewModel { AreaShopListViewModel(get()) }
-        viewModel { EditAreaViewModel(get(), get(), get(), get()) }
+        viewModel { EditAreaViewModel(get(), get(), get(), get(), get()) }
         viewModel { EditAreaSortViewModel(get(), get()) }
         viewModel { EditReportViewModel(get(), get(), get(), get()) }
         viewModel { EditShopViewModel(get(), get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
@@ -20,17 +20,17 @@ import org.koin.dsl.module
 val viewModelModule =
     module {
         viewModel { AddAreaViewModel(get(), get()) }
-        viewModel { AddShopViewModel(get(), get(), get()) }
+        viewModel { AddShopViewModel(get(), get(), get(), get()) }
         viewModel { AreaShopListViewModel(get()) }
         viewModel { EditAreaViewModel(get(), get(), get(), get()) }
         viewModel { EditAreaSortViewModel(get(), get()) }
         viewModel { EditReportViewModel(get(), get(), get(), get()) }
         viewModel { EditShopViewModel(get(), get(), get(), get()) }
-        viewModel { HistoryViewModel(get(), get()) }
+        viewModel { HistoryViewModel(get(), get(), get(), get()) }
         viewModel { HomeViewModel(get(), get(), get(), get(), get(), get()) }
         viewModel { NoteViewModel(get(), get(), get()) }
-        viewModel { AddReportViewModel(get(), get()) }
-        viewModel { ShopViewModel(get(), get(), get(), get(), get()) }
+        viewModel { AddReportViewModel(get(), get(), get()) }
+        viewModel { ShopViewModel(get(), get(), get(), get(), get(), get()) }
         viewModel { ScheduleViewModel(get(), get(), get()) }
         viewModel { SettingsViewModel(get()) }
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
@@ -141,7 +141,7 @@ sealed interface Screen {
 
     @Serializable
     data class EditArea(
-        val areaName: String
+        val areaId: Int
     ) : Screen {
         override val route: String = getRouteName(EditArea::class)
 
@@ -435,8 +435,8 @@ fun MainNavigation() {
                             goToAddArea = {
                                 navController.navigate(Screen.AddArea)
                             },
-                            goToEditArea = { areaName ->
-                                navController.navigate(Screen.EditArea(areaName))
+                            goToEditArea = { areaId ->
+                                navController.navigate(Screen.EditArea(areaId))
                             },
                             goToEditAreaSort = {
                                 navController.navigate(Screen.EditAreaSort)
@@ -501,7 +501,7 @@ fun MainNavigation() {
                     composable<Screen.EditArea> { backStackEntry ->
                         val screen: Screen.EditArea = backStackEntry.toRoute()
                         EditAreaScreen(
-                            areaName = screen.areaName,
+                            areaId = screen.areaId,
                             onBackClick = { navController.popBackStack() },
                             onCompleted = { navController.popBackStack() }
                         )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
@@ -269,6 +269,9 @@ fun MainNavigation() {
     // HistoryScreenに遷移する際のshopIdを管理するState
     var shopIdParam by remember { mutableStateOf<Int?>(null) }
 
+    // HistoryScreenに遷移する際のareaIdを管理するState
+    var areaIdParam by remember { mutableStateOf<Int?>(null) }
+
     val tabScreens =
         listOf(
             Screen.Home,
@@ -440,6 +443,15 @@ fun MainNavigation() {
                             },
                             goToShop = { shop ->
                                 navController.navigate(Screen.Shop(shop.id, shop.name))
+                            },
+                            goToHistoryWithAreaFiltering = { areaId ->
+                                areaIdParam = areaId
+                                navController.navigate(Screen.History) {
+                                    launchSingleTop = true
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                }
                             }
                         )
                     }
@@ -447,6 +459,7 @@ fun MainNavigation() {
                         HistoryScreen(
                             reportId = reportIdParam,
                             shopId = shopIdParam,
+                            areaId = areaIdParam,
                             goToEditReport = { reportId ->
                                 navController.navigate(Screen.EditReport(reportId))
                             },
@@ -455,6 +468,9 @@ fun MainNavigation() {
                             },
                             clearShopParam = {
                                 shopIdParam = null
+                            },
+                            clearAreaParam = {
+                                areaIdParam = null
                             }
                         )
                     }
@@ -544,7 +560,7 @@ fun MainNavigation() {
                                 // エラーの場合はデフォルトのShopオブジェクトを作成
                                 ShopInfo(
                                     name = "エラー",
-                                    area = "",
+                                    areaId = 0,
                                     shopUrl = "",
                                     mapUrl = "",
                                     star = 0,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopItem.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopItem.kt
@@ -96,7 +96,7 @@ fun ShopItemPreview() {
                     Shop(
                         id = 1,
                         name = "一風堂 博多本店",
-                        area = "福岡県",
+                        areaId = 1,
                         shopUrl = "https://www.ippudo.com/",
                         mapUrl = "",
                         star = 3,
@@ -114,7 +114,7 @@ fun ShopItemPreview() {
                     Shop(
                         id = 2,
                         name = "ラーメン横綱",
-                        area = "東京都",
+                        areaId = 2,
                         shopUrl = "",
                         mapUrl = "",
                         star = 2,
@@ -132,7 +132,7 @@ fun ShopItemPreview() {
                     Shop(
                         id = 3,
                         name = "つけ麺専門店 大勝軒 池袋店",
-                        area = "東京都",
+                        areaId = 2,
                         shopUrl = "",
                         mapUrl = "",
                         star = 1,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -41,20 +41,32 @@ import ramennote.composeapp.generated.resources.screen_history_title
 fun HistoryScreen(
     reportId: Int? = null,
     shopId: Int? = null,
+    areaId: Int? = null,
     goToEditReport: (reportId: Int) -> Unit = {},
     clearReportIdParam: () -> Unit = {},
     clearShopParam: () -> Unit = {},
+    clearAreaParam: () -> Unit = {},
     viewModel: HistoryViewModelContract = koinViewModel<HistoryViewModel>()
 ) {
     val shopNameState by viewModel.shopName.collectAsState()
+    val areaNameState by viewModel.areaName.collectAsState()
     val reportsState by viewModel.reports.collectAsState()
     val listState = rememberLazyListState()
     var selectedImageBytes by remember { mutableStateOf<ByteArray?>(null) }
     val xShareLauncher = createRememberedXShareLauncher()
 
     LaunchedEffect(Unit) {
-        viewModel.loadReports(shopId)
-        clearShopParam()
+        when {
+            areaId != null -> {
+                viewModel.loadReportsByArea(areaId)
+                clearAreaParam()
+            }
+            shopId != null -> {
+                viewModel.loadReportsByShop(shopId)
+                clearShopParam()
+            }
+            else -> viewModel.loadReports()
+        }
     }
 
     Column(
@@ -65,10 +77,12 @@ fun HistoryScreen(
     ) {
         AppBar(
             title =
-                if (shopNameState.isNotEmpty()) {
-                    "${stringResource(Res.string.screen_history_title)}($shopNameState)"
-                } else {
-                    stringResource(Res.string.screen_history_title)
+                when {
+                    areaNameState.isNotEmpty() ->
+                        "${stringResource(Res.string.screen_history_title)}($areaNameState)"
+                    shopNameState.isNotEmpty() ->
+                        "${stringResource(Res.string.screen_history_title)}($shopNameState)"
+                    else -> stringResource(Res.string.screen_history_title)
                 }
         )
         if (reportsState.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
@@ -3,8 +3,10 @@ package dev.seabat.ramennote.ui.screens.history
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.seabat.ramennote.domain.model.FullReport
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByAreaUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadFullReportsByShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsUseCaseContract
-import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import dev.seabat.ramennote.ui.share.XShareLauncher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +16,9 @@ import kotlinx.coroutines.launch
 
 class HistoryViewModel(
     private val loadReportsUseCase: LoadFullReportsUseCaseContract,
-    private val loadShopUseCase: LoadShopUseCaseContract
+    private val loadReportsByShopUseCase: LoadFullReportsByShopUseCaseContract,
+    private val loadReportsByAreaUseCase: LoadFullReportsByAreaUseCaseContract,
+    private val loadAreasUseCase: LoadAreasUseCaseContract
 ) : ViewModel(),
     HistoryViewModelContract {
     private val _reports = MutableStateFlow<List<FullReport>>(emptyList())
@@ -23,12 +27,32 @@ class HistoryViewModel(
     private val _shopName = MutableStateFlow<String>("")
     override val shopName: StateFlow<String> = _shopName.asStateFlow()
 
-    override fun loadReports(shopId: Int?) {
+    private val _areaName = MutableStateFlow<String>("")
+    override val areaName: StateFlow<String> = _areaName.asStateFlow()
+
+    override fun loadReports() {
         viewModelScope.launch {
-            _reports.value = loadReportsUseCase.invoke(shopId)
-            if (shopId != null) {
-                _shopName.value = loadShopUseCase.invoke(shopId)?.name ?: ""
-            }
+            _shopName.value = ""
+            _areaName.value = ""
+            _reports.value = loadReportsUseCase.invoke()
+        }
+    }
+
+    override fun loadReportsByShop(shopId: Int) {
+        viewModelScope.launch {
+            _areaName.value = ""
+            _reports.value = loadReportsByShopUseCase.invoke(shopId)
+            // 店舗名は FullReport.shopName から取得
+            _shopName.value = _reports.value.firstOrNull()?.shopName ?: ""
+        }
+    }
+
+    override fun loadReportsByArea(areaId: Int) {
+        viewModelScope.launch {
+            _shopName.value = ""
+            _reports.value = loadReportsByAreaUseCase.invoke(areaId)
+            // エリア名を areas テーブルから取得
+            _areaName.value = loadAreasUseCase().find { it.areaId == areaId }?.name ?: ""
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModelContract.kt
@@ -8,8 +8,13 @@ import kotlinx.coroutines.flow.StateFlow
 interface HistoryViewModelContract {
     val reports: StateFlow<List<FullReport>>
     val shopName: StateFlow<String>
+    val areaName: StateFlow<String>
 
-    fun loadReports(shopId: Int? = null)
+    fun loadReports()
+
+    fun loadReportsByShop(shopId: Int)
+
+    fun loadReportsByArea(areaId: Int)
 
     fun shareToX(postText: String, image: SharedImage?, xShareLauncher: XShareLauncher)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
@@ -15,12 +15,15 @@ class MockHistoryViewModel : HistoryViewModelContract {
     private val _shopName = MutableStateFlow<String>("")
     override val shopName: StateFlow<String> = _shopName.asStateFlow()
 
+    private val _areaName = MutableStateFlow<String>("")
+    override val areaName: StateFlow<String> = _areaName.asStateFlow()
+
     init {
         // プレビューで LaunchedEffect が動かない場合でも表示されるよう初期化
         loadReports()
     }
 
-    override fun loadReports(shopId: Int?) {
+    override fun loadReports() {
         _reports.value =
             listOf(
                 FullReport(
@@ -90,6 +93,14 @@ class MockHistoryViewModel : HistoryViewModelContract {
                     star = 3
                 )
             )
+    }
+
+    override fun loadReportsByShop(shopId: Int) {
+        // Preview用なので何もしない
+    }
+
+    override fun loadReportsByArea(areaId: Int) {
+        // Preview用なので何もしない
     }
 
     override fun shareToX(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportViewModel.kt
@@ -6,6 +6,7 @@ import dev.seabat.ramennote.domain.model.Report
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.usecase.AddReportUseCaseContract
 import dev.seabat.ramennote.domain.usecase.CreateReportPhotoNameUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import dev.seabat.ramennote.ui.share.XShareLauncher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +17,8 @@ import kotlinx.datetime.LocalDate
 
 class AddReportViewModel(
     private val createReportPhotoNameUseCase: CreateReportPhotoNameUseCaseContract,
-    private val addReportUseCase: AddReportUseCaseContract
+    private val addReportUseCase: AddReportUseCaseContract,
+    private val loadShopUseCase: LoadShopUseCaseContract
 ) : ViewModel(),
     AddReportViewModelContract {
     private val _reportedStatus = MutableStateFlow<RunStatus<Int>>(RunStatus.Idle())
@@ -34,6 +36,9 @@ class AddReportViewModel(
             try {
                 _reportedStatus.value = RunStatus.Loading()
 
+                // shopId から areaId を取得
+                val areaId = loadShopUseCase.invoke(shopId)?.areaId ?: 0
+
                 // AddReportUseCaseで画像保存とSQLite保存
                 val result =
                     addReportUseCase.invoke(
@@ -45,7 +50,8 @@ class AddReportViewModel(
                                 photoName = createReportPhotoNameUseCase(),
                                 impression = impression,
                                 date = reportedDate,
-                                star = star
+                                star = star,
+                                areaId = areaId
                             ),
                         imageBytes = image?.toByteArray()
                     )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportViewModel.kt
@@ -66,7 +66,8 @@ class EditReportViewModel(
                                 },
                             impression = impression,
                             date = reportedDate,
-                            star = star
+                            star = star,
+                            areaId = currentReport.areaId
                         ),
                     imageBytes = image?.toByteArray()
                 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -962,7 +962,7 @@ fun FavoriteShopItemPreview() {
                     Shop(
                         id = 1,
                         name = "一風堂",
-                        area = "福岡県",
+                        areaId = 1,
                         shopUrl = "https://www.ippudo.com/",
                         mapUrl = "",
                         star = 5,
@@ -980,7 +980,7 @@ fun FavoriteShopItemPreview() {
                     Shop(
                         id = 2,
                         name = "博多一風堂本店 天神地下街店 とんこつラーメン専門店",
-                        area = "福岡県",
+                        areaId = 1,
                         shopUrl = "https://www.ippudo.com/",
                         mapUrl = "",
                         star = 5,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
@@ -95,7 +95,7 @@ class MockHomeViewModel : HomeViewModelContract {
                         Shop(
                             id = 1,
                             name = "一風堂 博多本店",
-                            area = "福岡",
+                            areaId = 1,
                             shopUrl = "https://www.ippudo.com/",
                             mapUrl = "https://maps.google.com/",
                             star = 3,
@@ -119,7 +119,7 @@ class MockHomeViewModel : HomeViewModelContract {
                         Shop(
                             id = 2,
                             name = "一風堂 山口店",
-                            area = "山口",
+                            areaId = 2,
                             shopUrl = "https://www.ippudo.com/",
                             mapUrl = "https://maps.google.com/",
                             star = 3,
@@ -143,7 +143,7 @@ class MockHomeViewModel : HomeViewModelContract {
                         Shop(
                             id = 3,
                             name = "一風堂 広島店",
-                            area = "広島",
+                            areaId = 3,
                             shopUrl = "https://www.ippudo.com/",
                             mapUrl = "https://maps.google.com/",
                             star = 3,
@@ -167,7 +167,7 @@ class MockHomeViewModel : HomeViewModelContract {
                         Shop(
                             id = 4,
                             name = "一風堂 倉敷店",
-                            area = "岡山",
+                            areaId = 4,
                             shopUrl = "https://www.ippudo.com/",
                             mapUrl = "https://maps.google.com/",
                             star = 3,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/AreaWithImage.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/AreaWithImage.kt
@@ -6,5 +6,6 @@ data class AreaWithImage(
     val name: String,
     val updatedDate: LocalDate,
     val count: Int,
+    val areaId: Int = 0,
     val imageBytes: ByteArray? = null
 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/MockNoteViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/MockNoteViewModel.kt
@@ -15,10 +15,10 @@ class MockNoteViewModel : NoteViewModelContract {
     private val _areas: MutableStateFlow<List<AreaWithImage>> =
         MutableStateFlow(
             listOf(
-                AreaWithImage(name = "東京", updatedDate = LocalDate(2024, 9, 1), count = 12),
-                AreaWithImage(name = "神奈川", updatedDate = LocalDate(2024, 8, 21), count = 5),
-                AreaWithImage(name = "徳島", updatedDate = LocalDate(2024, 7, 3), count = 2),
-                AreaWithImage(name = "愛媛", updatedDate = LocalDate(2024, 6, 14), count = 7)
+                AreaWithImage(areaId = 1, name = "東京", updatedDate = LocalDate(2024, 9, 1), count = 12),
+                AreaWithImage(areaId = 2, name = "神奈川", updatedDate = LocalDate(2024, 8, 21), count = 5),
+                AreaWithImage(areaId = 3, name = "徳島", updatedDate = LocalDate(2024, 7, 3), count = 2),
+                AreaWithImage(areaId = 4, name = "愛媛", updatedDate = LocalDate(2024, 6, 14), count = 7)
             )
         )
     override val areas: StateFlow<List<AreaWithImage>> = _areas.asStateFlow()
@@ -29,7 +29,7 @@ class MockNoteViewModel : NoteViewModelContract {
                 Shop(
                     id = 1,
                     name = "一風堂 博多本店",
-                    area = "福岡",
+                    areaId = 1,
                     shopUrl = "https://www.ippudo.com/",
                     mapUrl = "https://maps.google.com/",
                     star = 3,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import dev.seabat.ramennote.ui.components.button.ReportListButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,6 +52,7 @@ import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.banner.HintBanner
 import dev.seabat.ramennote.ui.components.button.ActionButton
 import dev.seabat.ramennote.ui.components.button.AddFab
+import dev.seabat.ramennote.ui.components.button.ReportListButton
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
 import dev.seabat.ramennote.ui.screens.note.shop.SearchInputField
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
@@ -78,7 +78,7 @@ fun NoteScreen(
     initialSearchText: String = "",
     goToAreaShopList: (String) -> Unit = {},
     goToAddArea: () -> Unit = {},
-    goToEditArea: (String) -> Unit = {},
+    goToEditArea: (Int) -> Unit = {},
     goToEditAreaSort: () -> Unit = {},
     goToShop: (Shop) -> Unit = {},
     goToHistoryWithAreaFiltering: (areaId: Int) -> Unit = {},
@@ -115,7 +115,7 @@ private fun MainContent(
     viewModel: NoteViewModelContract,
     onAreaClick: (String) -> Unit = {},
     onAddAreaClick: () -> Unit = {},
-    onAreaLongClick: (String) -> Unit = {},
+    onAreaLongClick: (Int) -> Unit = {},
     onSortClick: () -> Unit = {},
     onShopClick: (Shop) -> Unit = {},
     onAreaReportClick: (areaId: Int) -> Unit = {},
@@ -250,7 +250,7 @@ private fun MainContent(
                                     imageBytes = area.imageBytes,
                                     itemCount = "${area.count}${stringResource(Res.string.note_item_count)}",
                                     onClick = { onAreaClick(area.name) },
-                                    onLongClick = { onAreaLongClick(area.name) },
+                                    onLongClick = { onAreaLongClick(area.areaId) },
                                     onReportClick = { onAreaReportClick(area.areaId) }
                                 )
                             }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import dev.seabat.ramennote.ui.components.button.ReportListButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -80,6 +81,7 @@ fun NoteScreen(
     goToEditArea: (String) -> Unit = {},
     goToEditAreaSort: () -> Unit = {},
     goToShop: (Shop) -> Unit = {},
+    goToHistoryWithAreaFiltering: (areaId: Int) -> Unit = {},
     viewModel: NoteViewModelContract = koinViewModel<NoteViewModel>()
 ) {
     Column(
@@ -96,6 +98,7 @@ fun NoteScreen(
             onAreaLongClick = goToEditArea,
             onSortClick = goToEditAreaSort,
             onShopClick = goToShop,
+            onAreaReportClick = goToHistoryWithAreaFiltering,
             initialSearchText = initialSearchText
         )
     }
@@ -115,6 +118,7 @@ private fun MainContent(
     onAreaLongClick: (String) -> Unit = {},
     onSortClick: () -> Unit = {},
     onShopClick: (Shop) -> Unit = {},
+    onAreaReportClick: (areaId: Int) -> Unit = {},
     initialSearchText: String = ""
 ) {
     BoxWithConstraints(
@@ -246,7 +250,8 @@ private fun MainContent(
                                     imageBytes = area.imageBytes,
                                     itemCount = "${area.count}${stringResource(Res.string.note_item_count)}",
                                     onClick = { onAreaClick(area.name) },
-                                    onLongClick = { onAreaLongClick(area.name) }
+                                    onLongClick = { onAreaLongClick(area.name) },
+                                    onReportClick = { onAreaReportClick(area.areaId) }
                                 )
                             }
                         }
@@ -314,7 +319,8 @@ private fun AreaItem(
     imageBytes: ByteArray? = null,
     itemCount: String,
     onClick: () -> Unit,
-    onLongClick: () -> Unit = {}
+    onLongClick: () -> Unit = {},
+    onReportClick: () -> Unit = {}
 ) {
     Card(
         modifier =
@@ -381,7 +387,7 @@ private fun AreaItem(
 
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
                         text = itemCount,
@@ -391,6 +397,7 @@ private fun AreaItem(
                             ),
                         color = Color.White.copy(alpha = 0.8f)
                     )
+                    ReportListButton(onClick = onReportClick)
                 }
             }
         }
@@ -401,7 +408,7 @@ private fun AreaItem(
 @Composable
 fun AreaItemPreview() {
     RamenNoteTheme {
-        AreaItem(areaName = "東京", imageBytes = null, itemCount = "12", onClick = {}, onLongClick = {})
+        AreaItem(areaName = "東京", imageBytes = null, itemCount = "12件", onClick = {}, onLongClick = {})
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteViewModel.kt
@@ -35,6 +35,7 @@ class NoteViewModel(
                 .map { area ->
                     val image = loadImageListUseCase(area.name)
                     AreaWithImage(
+                        areaId = area.areaId,
                         name = area.name,
                         count = area.count,
                         updatedDate = area.updatedDate,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -84,6 +85,11 @@ fun AddShopScreen(
 
     val saveState by viewModel.saveState.collectAsState()
     val shopAiInfoState by viewModel.shopAiInfoState.collectAsState()
+    val areaId by viewModel.areaIdState.collectAsState()
+
+    LaunchedEffect(areaName) {
+        viewModel.loadAreaId(areaName)
+    }
 
     var showShopAiInfoDialog by remember { mutableStateOf(true) }
 
@@ -250,7 +256,7 @@ fun AddShopScreen(
                     val shop =
                         Shop(
                             name = name,
-                            area = areaName,
+                            areaId = areaId,
                             shopUrl = shopUrl,
                             mapUrl = mapUrl,
                             star = star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -276,7 +276,8 @@ fun AddShopScreen(
         // 保存状態の処理
         SaveShopState(
             saveState = saveState,
-            onCompleted = onCompleted
+            onCompleted = onCompleted,
+            onErrorConfirm = { viewModel.setSaveStateToIdle() }
         )
         ShopAiInfoState(
             shopAiInfoState = shopAiInfoState,
@@ -287,7 +288,8 @@ fun AddShopScreen(
                 stationName = aiInfo.stationName
                 category = aiInfo.category
                 note = aiInfo.description
-            }
+            },
+            onErrorConfirm = { viewModel.setShopAiInfoStateToIdle() }
         )
     }
 }
@@ -373,7 +375,8 @@ private fun StarRating(
 @Composable
 private fun SaveShopState(
     saveState: RunStatus<String>,
-    onCompleted: () -> Unit
+    onCompleted: () -> Unit,
+    onErrorConfirm: () -> Unit
 ) {
     when (saveState) {
         is RunStatus.Success -> {
@@ -385,21 +388,22 @@ private fun SaveShopState(
         is RunStatus.Error -> {
             AppAlert(
                 message = saveState.message ?: "不明なエラーが発生しました",
-                onConfirm = { /* エラー処理 */ }
+                onConfirm = onErrorConfirm
             )
         }
-        else -> { /* その他の状態は何もしない */ }
+        is RunStatus.Idle -> { /* その他の状態は何もしない */ }
     }
 }
 
 @Composable
 private fun ShopAiInfoState(
     shopAiInfoState: RunStatus<ShopAiInfo>,
-    onShopUpdate: (ShopAiInfo) -> Unit
+    onShopUpdate: (ShopAiInfo) -> Unit,
+    onErrorConfirm: () -> Unit
 ) {
-    when (val state = shopAiInfoState) {
+    when (shopAiInfoState) {
         is RunStatus.Success -> {
-            state.data?.let { aiInfo ->
+            shopAiInfoState.data?.let { aiInfo ->
                 onShopUpdate(aiInfo)
             }
         }
@@ -408,11 +412,11 @@ private fun ShopAiInfoState(
         }
         is RunStatus.Error -> {
             AppAlert(
-                message = state.message ?: "店舗情報の取得に失敗しました",
-                onConfirm = { /* エラー処理 */ }
+                message = shopAiInfoState.message ?: "店舗情報の取得に失敗しました",
+                onConfirm = onErrorConfirm
             )
         }
-        else -> { /* その他の状態は何もしない */ }
+        is RunStatus.Idle -> { /* その他の状態は何もしない */ }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModel.kt
@@ -8,6 +8,7 @@ import dev.seabat.ramennote.domain.model.ShopAiInfo
 import dev.seabat.ramennote.domain.usecase.AddShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.CreateNoImageByteArrayUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchAiShopUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +18,8 @@ import kotlinx.coroutines.launch
 class AddShopViewModel(
     private val addShopUseCase: AddShopUseCaseContract,
     private val createNoImageUseCase: CreateNoImageByteArrayUseCaseContract,
-    private val fetchAiShopInfoUseCase: FetchAiShopUseCaseContract
+    private val fetchAiShopInfoUseCase: FetchAiShopUseCaseContract,
+    private val loadAreasUseCase: LoadAreasUseCaseContract
 ) : ViewModel(),
     AddShopViewModelContract {
     private val _saveState = MutableStateFlow<RunStatus<String>>(RunStatus.Idle())
@@ -25,6 +27,9 @@ class AddShopViewModel(
 
     private val _shopAiInfoState = MutableStateFlow<RunStatus<ShopAiInfo>>(RunStatus.Idle())
     override val shopAiInfoState: StateFlow<RunStatus<ShopAiInfo>> = _shopAiInfoState.asStateFlow()
+
+    private val _areaIdState = MutableStateFlow<Int>(0)
+    override val areaIdState: StateFlow<Int> = _areaIdState.asStateFlow()
 
     override fun saveShop(shop: Shop, sharedImage: SharedImage?) {
         viewModelScope.launch {
@@ -59,5 +64,12 @@ class AddShopViewModel(
 
     override fun setShopAiInfoStateToIdle() {
         _shopAiInfoState.value = RunStatus.Idle()
+    }
+
+    override fun loadAreaId(areaName: String) {
+        viewModelScope.launch {
+            val areas = loadAreasUseCase()
+            _areaIdState.value = areas.find { it.name == areaName }?.areaId ?: 0
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopViewModelContract.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface AddShopViewModelContract {
     val saveState: StateFlow<RunStatus<String>>
     val shopAiInfoState: StateFlow<RunStatus<ShopAiInfo>>
+    val areaIdState: StateFlow<Int>
 
     fun saveShop(shop: Shop, sharedImage: SharedImage?)
 
@@ -19,4 +20,6 @@ interface AddShopViewModelContract {
     fun fetchShopAiInfo(areaName: String, shopName: String)
 
     fun setShopAiInfoStateToIdle()
+
+    fun loadAreaId(areaName: String)
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/MockAddShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/MockAddShopViewModel.kt
@@ -15,6 +15,9 @@ class MockAddShopViewModel : AddShopViewModelContract {
     private val _shopAiInfoState = MutableStateFlow<RunStatus<ShopAiInfo>>(RunStatus.Idle())
     override val shopAiInfoState: StateFlow<RunStatus<ShopAiInfo>> = _shopAiInfoState.asStateFlow()
 
+    private val _areaIdState = MutableStateFlow<Int>(0)
+    override val areaIdState: StateFlow<Int> = _areaIdState.asStateFlow()
+
     override fun saveShop(shop: Shop, sharedImage: SharedImage?) {
         // Preview用なので何もしない
     }
@@ -30,6 +33,10 @@ class MockAddShopViewModel : AddShopViewModelContract {
     }
 
     override fun setShopAiInfoStateToIdle() {
+        // Preview用なので何もしない
+    }
+
+    override fun loadAreaId(areaName: String) {
         // Preview用なので何もしない
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -57,6 +57,7 @@ fun EditAreaScreen(
     viewModel: EditAreaViewModelContract = koinViewModel<EditAreaViewModel>()
 ) {
     LaunchedEffect(Unit) {
+        viewModel.loadAreaName(areaId)
         viewModel.loadImage(areaId)
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -51,20 +51,20 @@ import ramennote.composeapp.generated.resources.editarea_title
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditAreaScreen(
-    areaName: String,
+    areaId: Int,
     onBackClick: () -> Unit,
     onCompleted: () -> Unit,
     viewModel: EditAreaViewModelContract = koinViewModel<EditAreaViewModel>()
 ) {
     LaunchedEffect(Unit) {
-        viewModel.currentAreaName = areaName
-        viewModel.loadImage(areaName)
+        viewModel.loadImage(areaId)
     }
 
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        var areaName by remember { mutableStateOf(areaName) }
+        val currentAreaName by viewModel.areaName.collectAsState()
+        var areaNameInput by remember(currentAreaName) { mutableStateOf(currentAreaName) }
         var shouldShowAlert by remember { mutableStateOf(false) }
         val deleteStatus by viewModel.deleteState.collectAsState()
         val editStatus by viewModel.editState.collectAsState()
@@ -94,8 +94,8 @@ fun EditAreaScreen(
                     Text(text = "エリア", style = MaterialTheme.typography.titleMedium)
                     Spacer(Modifier.height(8.dp))
                     OutlinedTextField(
-                        value = areaName,
-                        onValueChange = { areaName = it },
+                        value = areaNameInput,
+                        onValueChange = { areaNameInput = it },
                         modifier = Modifier.fillMaxWidth(),
                         colors =
                             OutlinedTextFieldDefaults.colors(
@@ -114,7 +114,7 @@ fun EditAreaScreen(
                     Spacer(Modifier.height(16.dp))
 
                     Button(
-                        onClick = { viewModel.fetchImage(areaName) },
+                        onClick = { viewModel.fetchNewImage(areaId) },
                         colors =
                             ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,
@@ -159,9 +159,9 @@ fun EditAreaScreen(
                 Spacer(Modifier.weight(1.0f))
 
                 BottomButtons(
-                    areaName = areaName,
+                    areaName = areaNameInput,
                     onEditButtonClick = {
-                        viewModel.editArea(areaName)
+                        viewModel.editArea(areaId, areaNameInput)
                     },
                     onDeleteButtonClick = {
                         shouldShowAlert = true
@@ -172,9 +172,9 @@ fun EditAreaScreen(
 
         if (shouldShowAlert) {
             AppTwoButtonAlert(
-                message = stringResource(Res.string.editarea_delete_confirm, areaName),
+                message = stringResource(Res.string.editarea_delete_confirm, areaNameInput),
                 onConfirm = {
-                    viewModel.deleteArea(areaName)
+                    viewModel.deleteArea(areaId)
                     shouldShowAlert = false
                 },
                 onNegative = {
@@ -255,10 +255,10 @@ fun DeleteStatus(
 
 @Preview
 @Composable
-fun EditAreaScreen() {
+fun EditAreaScreenPreview() {
     RamenNoteTheme {
         EditAreaScreen(
-            areaName = "エリア名",
+            areaId = 1,
             onBackClick = {},
             onCompleted = {},
             viewModel = MockEditAreaViewModel()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -4,7 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.usecase.DeleteAreaUseCaseContract
-import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreaImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCaseContract
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +17,8 @@ class EditAreaViewModel(
     private val deleteAreaUseCase: DeleteAreaUseCaseContract,
     private val updateAreaUseCase: UpdateAreaUseCaseContract,
     private val updateAreaImageUseCase: UpdateAreaImageUseCaseContract,
-    private val loadImageUseCase: LoadImageUseCaseContract
+    private val loadAreaImageUseCase: LoadAreaImageUseCaseContract,
+    private val loadAreasUseCase: LoadAreasUseCaseContract
 ) : ViewModel(),
     EditAreaViewModelContract {
     private val _deleteState: MutableStateFlow<RunStatus<String>> =
@@ -31,34 +33,41 @@ class EditAreaViewModel(
         MutableStateFlow(RunStatus.Idle())
     override val imageState: StateFlow<RunStatus<ByteArray>> = _imageState.asStateFlow()
 
-    override var currentAreaName = ""
+    private val _areaName: MutableStateFlow<String> = MutableStateFlow("")
+    override val areaName: StateFlow<String> = _areaName.asStateFlow()
 
-    override fun editArea(newAreaName: String) {
+    override fun editArea(areaId: Int, newAreaName: String) {
         viewModelScope.launch {
             _editState.value = RunStatus.Loading()
-            _editState.value = updateAreaUseCase(currentAreaName, newAreaName)
-            currentAreaName = newAreaName
+            _editState.value = updateAreaUseCase(areaId, newAreaName)
+            if (_editState.value is RunStatus.Success) {
+                _areaName.value = newAreaName
+            }
         }
     }
 
-    override fun deleteArea(areaName: String) {
+    override fun deleteArea(areaId: Int) {
         viewModelScope.launch {
             _deleteState.value = RunStatus.Loading()
-            _editState.value = deleteAreaUseCase(areaName)
+            _editState.value = deleteAreaUseCase(areaId)
         }
     }
 
-    override fun fetchImage(areaName: String) {
+    override fun fetchNewImage(areaId: Int) {
         viewModelScope.launch {
             _imageState.value = RunStatus.Loading()
-            _imageState.value = updateAreaImageUseCase(areaName)
+            _imageState.value = updateAreaImageUseCase(areaId)
         }
     }
 
-    override fun loadImage(areaName: String) {
+    override fun loadImage(areaId: Int) {
         viewModelScope.launch {
+            // areaId からエリア名を取得して _areaName を設定
+            val areas = loadAreasUseCase()
+            _areaName.value = areas.find { it.areaId == areaId }?.name ?: ""
+
             _imageState.value = RunStatus.Loading()
-            _imageState.value = loadImageUseCase(areaName)
+            _imageState.value = loadAreaImageUseCase(areaId)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -60,12 +60,16 @@ class EditAreaViewModel(
         }
     }
 
-    override fun loadImage(areaId: Int) {
+    override fun loadAreaName(areaId: Int) {
         viewModelScope.launch {
             // areaId からエリア名を取得して _areaName を設定
             val areas = loadAreasUseCase()
             _areaName.value = areas.find { it.areaId == areaId }?.name ?: ""
+        }
+    }
 
+    override fun loadImage(areaId: Int) {
+        viewModelScope.launch {
             _imageState.value = RunStatus.Loading()
             _imageState.value = loadAreaImageUseCase(areaId)
         }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
@@ -7,15 +7,15 @@ interface EditAreaViewModelContract {
     val deleteState: StateFlow<RunStatus<String>>
     val editState: StateFlow<RunStatus<String>>
     val imageState: StateFlow<RunStatus<ByteArray>>
-    var currentAreaName: String
+    val areaName: StateFlow<String>
 
-    fun editArea(newArea: String)
+    fun editArea(areaId: Int, newAreaName: String)
 
-    fun deleteArea(area: String)
+    fun deleteArea(areaId: Int)
 
-    fun fetchImage(areaName: String)
+    fun fetchNewImage(areaId: Int)
 
-    fun loadImage(name: String)
+    fun loadImage(areaId: Int)
 
     fun resetImageState()
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
@@ -15,6 +15,8 @@ interface EditAreaViewModelContract {
 
     fun fetchNewImage(areaId: Int)
 
+    fun loadAreaName(areaId: Int)
+
     fun loadImage(areaId: Int)
 
     fun resetImageState()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
@@ -15,22 +15,22 @@ class MockEditAreaViewModel :
     EditAreaViewModelContract {
     override val deleteState: StateFlow<RunStatus<String>> = MutableStateFlow<RunStatus<String>>(RunStatus.Idle()).asStateFlow()
     override val editState: StateFlow<RunStatus<String>> = MutableStateFlow<RunStatus<String>>(RunStatus.Idle()).asStateFlow()
-    override var currentAreaName: String = ""
     override val imageState: StateFlow<RunStatus<ByteArray>> = MutableStateFlow<RunStatus<ByteArray>>(RunStatus.Idle()).asStateFlow()
+    override val areaName: StateFlow<String> = MutableStateFlow("エリア名").asStateFlow()
 
-    override fun editArea(newArea: String) {
+    override fun editArea(areaId: Int, newAreaName: String) {
         // Preview用なので何もしない
     }
 
-    override fun deleteArea(area: String) {
+    override fun deleteArea(areaId: Int) {
         // Preview用なので何もしない
     }
 
-    override fun fetchImage(areaName: String) {
+    override fun fetchNewImage(areaId: Int) {
         // Preview用なので何もしない
     }
 
-    override fun loadImage(name: String) {
+    override fun loadImage(areaId: Int) {
         // Preview用なので何もしない
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
@@ -30,6 +30,10 @@ class MockEditAreaViewModel :
         // Preview用なので何もしない
     }
 
+    override fun loadAreaName(areaId: Int) {
+        // Preview用なので何もしない
+    }
+
     override fun loadImage(areaId: Int) {
         // Preview用なので何もしない
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
@@ -72,7 +72,7 @@ fun EditShopScreen(
     viewModel: EditShopViewModelContract = koinViewModel<EditShopViewModel>()
 ) {
     var name by remember { mutableStateOf(shop.name) }
-    var area by remember { mutableStateOf(shop.area) }
+    var selectedAreaName by remember { mutableStateOf("") }
     var shopUrl by remember { mutableStateOf(shop.shopUrl) }
     var mapUrl by remember { mutableStateOf(shop.mapUrl) }
     var star by remember { mutableStateOf(shop.star) }
@@ -98,6 +98,13 @@ fun EditShopScreen(
     // エリアリスト読み込み
     LaunchedEffect(Unit) {
         viewModel.loadAreas()
+    }
+
+    // エリアリストが読み込まれたら初期選択値を設定
+    LaunchedEffect(areasState) {
+        if (selectedAreaName.isEmpty() && areasState.isNotEmpty()) {
+            selectedAreaName = areasState.find { it.areaId == shop.areaId }?.name ?: ""
+        }
     }
 
     PhotoSelectionHandler(
@@ -153,9 +160,9 @@ fun EditShopScreen(
                 // エリア
                 ShopDropdownField(
                     label = stringResource(Res.string.edit_area_label),
-                    options = areasState,
-                    value = area,
-                    onValueChange = { area = it }
+                    options = areasState.map { it.name },
+                    value = selectedAreaName,
+                    onValueChange = { selectedAreaName = it }
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -221,10 +228,11 @@ fun EditShopScreen(
                     text = stringResource(Res.string.edit_shop_edit_button),
                     enabled = name.isNotBlank(),
                     onClick = {
+                        val newAreaId = areasState.find { it.name == selectedAreaName }?.areaId ?: shop.areaId
                         val updatedShop =
                             shop.copy(
                                 name = name,
-                                area = area,
+                                areaId = newAreaId,
                                 shopUrl = shopUrl,
                                 mapUrl = mapUrl,
                                 star = star,
@@ -233,7 +241,7 @@ fun EditShopScreen(
                                 menuName1 = menuName,
                                 note = note
                             )
-                        viewModel.updateShop(updatedShop, shopImage, shop.area)
+                        viewModel.updateShop(updatedShop, shopImage, shop.areaId)
                     }
                 )
 
@@ -267,7 +275,7 @@ fun EditShopScreen(
         when (deleteState) {
             is RunStatus.Success -> {
                 LaunchedEffect(deleteState) {
-                    goToShopList(shop.area)
+                    goToShopList(areasState.find { it.areaId == shop.areaId }?.name ?: "")
                 }
             }
             is RunStatus.Error -> {
@@ -306,7 +314,7 @@ fun EditShopScreenPreview() {
     val shop =
         Shop(
             name = "XXXX家",
-            area = "東京",
+            areaId = 1,
             shopUrl = "https://example.com",
             mapUrl = "https://maps.google.com",
             star = 2,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModel.kt
@@ -2,6 +2,7 @@ package dev.seabat.ramennote.ui.screens.note.editshop
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.domain.usecase.DeleteShopAndImageUseCaseContract
@@ -30,8 +31,8 @@ class EditShopViewModel(
     private val _shopImage = MutableStateFlow<SharedImage?>(null)
     override val shopImage: StateFlow<SharedImage?> = _shopImage.asStateFlow()
 
-    private val _areasState = MutableStateFlow<List<String>>(emptyList())
-    override val areasState: StateFlow<List<String>> = _areasState.asStateFlow()
+    private val _areasState = MutableStateFlow<List<Area>>(emptyList())
+    override val areasState: StateFlow<List<Area>> = _areasState.asStateFlow()
 
     override fun loadImage(shop: Shop) {
         viewModelScope.launch {
@@ -57,12 +58,12 @@ class EditShopViewModel(
         _shopImage.value = sharedImage
     }
 
-    override fun updateShop(shop: Shop, sharedImage: SharedImage?, oldArea: String) {
+    override fun updateShop(shop: Shop, sharedImage: SharedImage?, oldAreaId: Int) {
         viewModelScope.launch {
             _saveState.value = RunStatus.Loading()
             try {
                 // 店舗情報と画像を更新
-                updateShopUseCase(shop, sharedImage?.toByteArray(), oldArea)
+                updateShopUseCase(shop, sharedImage?.toByteArray(), oldAreaId)
                 _saveState.value = RunStatus.Success("")
             } catch (e: Exception) {
                 _saveState.value = RunStatus.Error("店舗の更新に失敗しました: ${e.message}")
@@ -88,8 +89,7 @@ class EditShopViewModel(
 
     override fun loadAreas() {
         viewModelScope.launch {
-            val areasList = loadAreasUseCase()
-            _areasState.value = areasList.map { it.name }
+            _areasState.value = loadAreasUseCase()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelContract.kt
@@ -1,5 +1,6 @@
 package dev.seabat.ramennote.ui.screens.note.editshop
 
+import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.gallery.SharedImage
@@ -9,13 +10,13 @@ interface EditShopViewModelContract {
     val saveState: StateFlow<RunStatus<String>>
     val deleteState: StateFlow<RunStatus<String>>
     val shopImage: StateFlow<SharedImage?>
-    val areasState: StateFlow<List<String>>
+    val areasState: StateFlow<List<Area>>
 
     fun loadImage(shop: Shop)
 
     fun setImage(sharedImage: SharedImage?)
 
-    fun updateShop(shop: Shop, sharedImage: SharedImage?, oldArea: String)
+    fun updateShop(shop: Shop, sharedImage: SharedImage?, oldAreaId: Int)
 
     fun deleteShop(shopId: Int)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/MockEditShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/MockEditShopViewModel.kt
@@ -1,10 +1,12 @@
 package dev.seabat.ramennote.ui.screens.note.editshop
 
+import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.datetime.LocalDate
 
 class MockEditShopViewModel : EditShopViewModelContract {
     private val _saveState = MutableStateFlow<RunStatus<String>>(RunStatus.Idle())
@@ -16,8 +18,18 @@ class MockEditShopViewModel : EditShopViewModelContract {
     private val _shopImage = MutableStateFlow<SharedImage?>(null)
     override val shopImage: StateFlow<SharedImage?> = _shopImage
 
-    private val _areasState = MutableStateFlow<List<String>>(listOf("東京", "大阪", "京都", "北海道"))
-    override val areasState: StateFlow<List<String>> = _areasState
+    private val _areasState = MutableStateFlow<List<Area>>(emptyList())
+    override val areasState: StateFlow<List<Area>> = _areasState
+
+    init {
+        _areasState.value =
+            listOf(
+                Area(areaId = 1, name = "東京", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 1),
+                Area(areaId = 2, name = "大阪", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 2),
+                Area(areaId = 3, name = "京都", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 3),
+                Area(areaId = 4, name = "北海道", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 4)
+            )
+    }
 
     override fun loadImage(shop: Shop) {
         _shopImage.value = null
@@ -27,7 +39,7 @@ class MockEditShopViewModel : EditShopViewModelContract {
         _shopImage.value = null
     }
 
-    override fun updateShop(shop: Shop, sharedImage: SharedImage?, oldArea: String) {
+    override fun updateShop(shop: Shop, sharedImage: SharedImage?, oldAreaId: Int) {
         _saveState.value = RunStatus.Success("")
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/MockShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/MockShopViewModel.kt
@@ -13,7 +13,7 @@ class MockShopViewModel : ShopViewModelContract {
             Shop(
                 id = 1,
                 name = "XXXX家",
-                area = "東京",
+                areaId = 1,
                 shopUrl = "https://example.com",
                 mapUrl = "https://maps.google.com",
                 star = 2,
@@ -27,6 +27,9 @@ class MockShopViewModel : ShopViewModelContract {
 
     private val _shopImage = MutableStateFlow<ByteArray?>(null)
     override val shopImage: StateFlow<ByteArray?> = _shopImage
+
+    private val _areaName = MutableStateFlow<String>("東京")
+    override val areaName: StateFlow<String> = _areaName.asStateFlow()
 
     override fun loadShopAndImage(id: Int) {
         _shopImage.value = null

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
@@ -48,8 +48,6 @@ import dev.seabat.ramennote.ui.components.button.AddReportButton
 import dev.seabat.ramennote.ui.components.button.EditShopButton
 import dev.seabat.ramennote.ui.components.button.ReportListButton
 import dev.seabat.ramennote.ui.components.button.ScheduleButton
-
-import dev.seabat.ramennote.ui.components.button.ReportListButton
 import dev.seabat.ramennote.ui.screens.componens.ShopDetailItem
 import dev.seabat.ramennote.ui.screens.componens.ShopStarRatingRow
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
@@ -523,7 +521,6 @@ private fun datePickerOnClickHandler(
         dismissDatePicker()
     }
 }
-
 
 @Preview
 @Composable

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
@@ -44,7 +44,12 @@ import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.ShopStarIcon
 import dev.seabat.ramennote.ui.components.alert.AppAlert
-import dev.seabat.ramennote.ui.components.button.ActionButton
+import dev.seabat.ramennote.ui.components.button.AddReportButton
+import dev.seabat.ramennote.ui.components.button.EditShopButton
+import dev.seabat.ramennote.ui.components.button.ReportListButton
+import dev.seabat.ramennote.ui.components.button.ScheduleButton
+
+import dev.seabat.ramennote.ui.components.button.ReportListButton
 import dev.seabat.ramennote.ui.screens.componens.ShopDetailItem
 import dev.seabat.ramennote.ui.screens.componens.ShopStarRatingRow
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
@@ -55,7 +60,6 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.composeapp.generated.resources.Res
@@ -68,19 +72,11 @@ import ramennote.composeapp.generated.resources.add_schedule_error_past_date_mes
 import ramennote.composeapp.generated.resources.add_schedule_label
 import ramennote.composeapp.generated.resources.add_station_label
 import ramennote.composeapp.generated.resources.add_web_site_label
-import ramennote.composeapp.generated.resources.edit_24px
 import ramennote.composeapp.generated.resources.edit_area_label
-import ramennote.composeapp.generated.resources.event_note_24px
 import ramennote.composeapp.generated.resources.favorite_disabled
 import ramennote.composeapp.generated.resources.favorite_enabled
-import ramennote.composeapp.generated.resources.ramen_dining_24px
 import ramennote.composeapp.generated.resources.schedule_picker_label
 import ramennote.composeapp.generated.resources.shop_map_label
-import ramennote.composeapp.generated.resources.shop_menu_edit_button
-import ramennote.composeapp.generated.resources.shop_menu_history_button
-import ramennote.composeapp.generated.resources.shop_menu_report_button
-import ramennote.composeapp.generated.resources.shop_menu_schedule_add_button
-import ramennote.composeapp.generated.resources.shop_menu_schedule_edit_button
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -101,6 +97,7 @@ fun ShopScreen(
 
     val shop by viewModel.shop.collectAsState()
     val imageBytes by viewModel.shopImage.collectAsState()
+    val areaName by viewModel.areaName.collectAsState()
 
     var showDatePicker by remember { mutableStateOf(false) }
     var showErrorDialog by remember { mutableStateOf(false) }
@@ -155,6 +152,7 @@ fun ShopScreen(
                 shop?.let { shopData ->
                     Detail(
                         shopData,
+                        areaName = areaName,
                         updateStar = { newStar ->
                             viewModel.updateStar(newStar, shopId)
                         }
@@ -345,17 +343,17 @@ fun Menu(
             modifier = Modifier.weight(1f)
         )
 
-        ReportButton(
+        AddReportButton(
             onClick = onReportClick,
             modifier = Modifier.weight(1f)
         )
 
-        HistoryButton(
+        ReportListButton(
             onClick = onHistoryClick,
             modifier = Modifier.weight(1f)
         )
 
-        EditButton(
+        EditShopButton(
             onClick = onEditClick,
             modifier = Modifier.weight(1f)
         )
@@ -365,6 +363,7 @@ fun Menu(
 @Composable
 fun Detail(
     shop: Shop,
+    areaName: String = "",
     updateStar: (Int) -> Unit = { }
 ) {
     Column(
@@ -388,7 +387,7 @@ fun Detail(
         // エリア
         ShopDetailItem(
             label = stringResource(Res.string.edit_area_label),
-            value = shop.area.ifEmpty { stringResource(Res.string.add_no_data_label) }
+            value = areaName.ifEmpty { stringResource(Res.string.add_no_data_label) }
         )
 
         // Webサイト
@@ -525,90 +524,6 @@ private fun datePickerOnClickHandler(
     }
 }
 
-@Composable
-private fun ScheduleButton(
-    hasScheduledDate: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val buttonText =
-        if (hasScheduledDate) {
-            stringResource(Res.string.shop_menu_schedule_edit_button)
-        } else {
-            stringResource(Res.string.shop_menu_schedule_add_button)
-        }
-    ActionButton(
-        icon = vectorResource(Res.drawable.event_note_24px),
-        text = buttonText,
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun ReportButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    ActionButton(
-        icon = vectorResource(Res.drawable.ramen_dining_24px),
-        text = stringResource(Res.string.shop_menu_report_button),
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun HistoryButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    ActionButton(
-        icon = vectorResource(Res.drawable.ramen_dining_24px),
-        text = stringResource(Res.string.shop_menu_history_button),
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun EditButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    ActionButton(
-        icon = vectorResource(Res.drawable.edit_24px),
-        text = stringResource(Res.string.shop_menu_edit_button),
-        onClick = onClick,
-        modifier = modifier
-    )
-}
-
-@Preview
-@Composable
-private fun ActionButtonPreview() {
-    RamenNoteTheme {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            // 予定追加
-            ScheduleButton(
-                hasScheduledDate = false,
-                onClick = {}
-            )
-            // 予定変更
-            ScheduleButton(
-                hasScheduledDate = true,
-                onClick = {}
-            )
-            // 食レポ
-            ReportButton(onClick = {})
-            // 編集
-            EditButton(onClick = {})
-        }
-    }
-}
 
 @Preview
 @Composable

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SwitchFavoriteUseCaseContract
@@ -19,7 +20,8 @@ class ShopViewModel(
     private val loadImageUseCase: LoadImageUseCaseContract,
     private val addScheduleUseCase: UpdateScheduleInShopUseCaseContract,
     private val switchFavoriteUseCase: SwitchFavoriteUseCaseContract,
-    private val updateStarUseCase: UpdateStarUseCaseContract
+    private val updateStarUseCase: UpdateStarUseCaseContract,
+    private val loadAreasUseCase: LoadAreasUseCaseContract
 ) : ViewModel(),
     ShopViewModelContract {
     private val _shop = MutableStateFlow<Shop?>(null)
@@ -28,11 +30,18 @@ class ShopViewModel(
     private val _shopImage = MutableStateFlow<ByteArray?>(null)
     override val shopImage: StateFlow<ByteArray?> = _shopImage.asStateFlow()
 
+    private val _areaName = MutableStateFlow<String>("")
+    override val areaName: StateFlow<String> = _areaName.asStateFlow()
+
     override fun loadShopAndImage(id: Int) {
         viewModelScope.launch {
             val shop = loadShopUseCase.invoke(id)
             _shop.value = shop
             _shopImage.value = shop?.let { loadShopImage(it.photoName1) }
+            shop?.let {
+                val areas = loadAreasUseCase()
+                _areaName.value = areas.find { area -> area.areaId == it.areaId }?.name ?: ""
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModelContract.kt
@@ -7,6 +7,7 @@ import kotlinx.datetime.LocalDate
 interface ShopViewModelContract {
     val shop: StateFlow<Shop?>
     val shopImage: StateFlow<ByteArray?>
+    val areaName: StateFlow<String>
 
     fun loadShopAndImage(id: Int)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/MockAreaShopListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/MockAreaShopListViewModel.kt
@@ -13,7 +13,7 @@ class MockAreaShopListViewModel : AreaShopListViewModelContract {
                 Shop(
                     id = 1,
                     name = "一風堂 博多本店",
-                    area = "福岡",
+                    areaId = 1,
                     shopUrl = "https://www.ippudo.com/",
                     mapUrl = "https://maps.google.com/",
                     star = 3,

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryTest.kt
@@ -1,0 +1,275 @@
+package dev.seabat.ramennote.data.repository
+
+import androidx.room.InvalidationTracker
+import dev.seabat.ramennote.data.database.RamenNoteDatabase
+import dev.seabat.ramennote.data.database.dao.AreaDao
+import dev.seabat.ramennote.data.database.entity.AreaEntity
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AreasRepositoryTest {
+
+    // --- load() ---
+
+    @Test
+    fun `load - DAOが返したエンティティをドメインモデルに変換して返す`() = runTest {
+        val entities = listOf(
+            AreaEntity(areaId = 1, name = "東京", count = 3, date = "2024-09-01", sort = 1),
+            AreaEntity(areaId = 2, name = "大阪", count = 1, date = "2024-08-15", sort = 2)
+        )
+        val dao = FakeAreaDao(areas = entities.toMutableList())
+        val repository = buildRepository(dao)
+
+        val result = repository.load()
+
+        assertEquals(2, result.size)
+        assertEquals(1, result[0].areaId)
+        assertEquals("東京", result[0].name)
+        assertEquals(3, result[0].count)
+        assertEquals(LocalDate.parse("2024-09-01"), result[0].updatedDate)
+        assertEquals(1, result[0].sort)
+        assertEquals(2, result[1].areaId)
+        assertEquals("大阪", result[1].name)
+    }
+
+    @Test
+    fun `load - DAOがエンティティを返さない場合は空リストを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.load()
+
+        assertTrue(result.isEmpty())
+    }
+
+    // --- load(areaName) ---
+
+    @Test
+    fun `load areaName - 一致するエリアをドメインモデルに変換して返す`() = runTest {
+        val entity = AreaEntity(areaId = 1, name = "東京", count = 5, date = "2024-09-01", sort = 1)
+        val dao = FakeAreaDao(areas = mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        val result = repository.load("東京")
+
+        assertEquals(1, result?.areaId)
+        assertEquals("東京", result?.name)
+        assertEquals(5, result?.count)
+    }
+
+    @Test
+    fun `load areaName - 一致するエリアがない場合はnullを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.load("存在しないエリア")
+
+        assertNull(result)
+    }
+
+    // --- loadByAreaId ---
+
+    @Test
+    fun `loadByAreaId - 一致するエリアをドメインモデルに変換して返す`() = runTest {
+        val entity = AreaEntity(areaId = 42, name = "福岡", count = 2, date = "2024-07-10", sort = 3)
+        val dao = FakeAreaDao(areas = mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        val result = repository.loadByAreaId(42)
+
+        assertEquals(42, result?.areaId)
+        assertEquals("福岡", result?.name)
+    }
+
+    @Test
+    fun `loadByAreaId - 一致するIDがない場合はnullを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.loadByAreaId(999)
+
+        assertNull(result)
+    }
+
+    // --- add ---
+
+    @Test
+    fun `add - maxSort + 1 のsortでエンティティが挿入される`() = runTest {
+        val existing = AreaEntity(areaId = 1, name = "東京", count = 0, date = "2024-01-01", sort = 3)
+        val dao = FakeAreaDao(areas = mutableListOf(existing))
+        val repository = buildRepository(dao)
+
+        repository.add(
+            Area(name = "大阪", count = 0, updatedDate = LocalDate.parse("2024-09-01"), sort = 0)
+        )
+
+        // sort は maxSort(3) + 1 = 4 になる
+        val inserted = dao.insertedArea
+        assertEquals("大阪", inserted?.name)
+        assertEquals(4, inserted?.sort)
+        assertEquals(0, inserted?.count)
+        assertEquals("2024-09-01", inserted?.date)
+    }
+
+    @Test
+    fun `add - エリアがひとつも登録されていない場合はsort=1で挿入される`() = runTest {
+        val dao = FakeAreaDao() // getMaxSort() は 0 を返す
+        val repository = buildRepository(dao)
+
+        repository.add(
+            Area(name = "北海道", count = 0, updatedDate = LocalDate.parse("2024-09-01"), sort = 0)
+        )
+
+        assertEquals(1, dao.insertedArea?.sort)
+    }
+
+    // --- edit(oldName, newName) ---
+
+    @Test
+    fun `edit oldName newName - 既存エリアの名前を更新してSuccessを返す`() = runTest {
+        val entity = AreaEntity(areaId = 1, name = "旧名称", count = 2, date = "2024-01-01", sort = 1)
+        val dao = FakeAreaDao(areas = mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        val result = repository.edit("旧名称", "新名称")
+
+        assertIs<RunStatus.Success<String>>(result)
+        assertEquals("新名称", dao.updatedArea?.name)
+        // areaId はそのまま維持される
+        assertEquals(1, dao.updatedArea?.areaId)
+    }
+
+    @Test
+    fun `edit oldName newName - 存在しないエリア名の場合はErrorを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.edit("存在しない", "新名称")
+
+        assertIs<RunStatus.Error<String>>(result)
+        assertTrue(result.message?.contains("存在しない") == true)
+    }
+
+    // --- edit(area) ---
+
+    @Test
+    fun `edit area - 既存エリアのcount・date・sortを更新してSuccessを返す`() = runTest {
+        val entity = AreaEntity(areaId = 1, name = "東京", count = 0, date = "2024-01-01", sort = 1)
+        val dao = FakeAreaDao(areas = mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        val result = repository.edit(
+            Area(areaId = 1, name = "東京", count = 5, updatedDate = LocalDate.parse("2025-03-01"), sort = 2)
+        )
+
+        assertIs<RunStatus.Success<String>>(result)
+        assertEquals(5, dao.updatedArea?.count)
+        assertEquals("2025-03-01", dao.updatedArea?.date)
+        assertEquals(2, dao.updatedArea?.sort)
+        // name と areaId はそのまま維持
+        assertEquals("東京", dao.updatedArea?.name)
+        assertEquals(1, dao.updatedArea?.areaId)
+    }
+
+    @Test
+    fun `edit area - 存在しないエリア名の場合はErrorを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.edit(
+            Area(name = "存在しない", count = 0, updatedDate = LocalDate.parse("2024-01-01"), sort = 1)
+        )
+
+        assertIs<RunStatus.Error<String>>(result)
+        assertTrue(result.message?.contains("存在しない") == true)
+    }
+
+    // --- delete ---
+
+    @Test
+    fun `delete - 既存エリアを削除してSuccessを返す`() = runTest {
+        val entity = AreaEntity(areaId = 1, name = "東京", count = 0, date = "2024-01-01", sort = 1)
+        val dao = FakeAreaDao(areas = mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        val result = repository.delete("東京")
+
+        assertIs<RunStatus.Success<String>>(result)
+        assertEquals(entity, dao.deletedArea)
+    }
+
+    @Test
+    fun `delete - 存在しないエリア名の場合はErrorを返す`() = runTest {
+        val dao = FakeAreaDao()
+        val repository = buildRepository(dao)
+
+        val result = repository.delete("存在しない")
+
+        assertIs<RunStatus.Error<String>>(result)
+        assertTrue(result.message?.contains("存在しない") == true)
+    }
+
+    // --- ヘルパー ---
+
+    private fun buildRepository(dao: FakeAreaDao): AreasRepository =
+        AreasRepository(areaDao = dao, database = FakeRamenNoteDatabase(dao))
+
+    // --- フェイク実装 ---
+
+    private class FakeAreaDao(
+        private val areas: MutableList<AreaEntity> = mutableListOf()
+    ) : AreaDao {
+        var insertedArea: AreaEntity? = null
+        var updatedArea: AreaEntity? = null
+        var deletedArea: AreaEntity? = null
+
+        override suspend fun getAllAreas(): List<AreaEntity> = areas
+
+        override fun getAllAreasFlow(): Flow<List<AreaEntity>> = flowOf(areas)
+
+        override suspend fun getAreaByName(name: String): AreaEntity? =
+            areas.find { it.name == name }
+
+        override suspend fun getAreaById(areaId: Int): AreaEntity? =
+            areas.find { it.areaId == areaId }
+
+        override suspend fun insertArea(area: AreaEntity) {
+            insertedArea = area
+            areas.add(area)
+        }
+
+        override suspend fun updateArea(area: AreaEntity) {
+            updatedArea = area
+            val index = areas.indexOfFirst { it.areaId == area.areaId }
+            if (index >= 0) areas[index] = area
+        }
+
+        override suspend fun deleteArea(area: AreaEntity) {
+            deletedArea = area
+            areas.removeAll { it.areaId == area.areaId }
+        }
+
+        override suspend fun deleteAreaByName(name: String) {
+            areas.removeAll { it.name == name }
+        }
+
+        override suspend fun getMaxSort(): Int = areas.maxOfOrNull { it.sort } ?: 0
+    }
+
+    private class FakeRamenNoteDatabase(private val dao: FakeAreaDao) : RamenNoteDatabase() {
+        override fun areaDao() = dao
+        override fun shopDao() = throw UnsupportedOperationException("テスト対象外")
+        override fun reportDao() = throw UnsupportedOperationException("テスト対象外")
+        override fun createInvalidationTracker(): InvalidationTracker =
+            InvalidationTracker(this, emptyMap(), emptyMap())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/AreasRepositoryTest.kt
@@ -271,5 +271,6 @@ class AreasRepositoryTest {
         override fun reportDao() = throw UnsupportedOperationException("テスト対象外")
         override fun createInvalidationTracker(): InvalidationTracker =
             InvalidationTracker(this, emptyMap(), emptyMap())
+        override fun clearAllTables() = Unit
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryTest.kt
@@ -343,5 +343,6 @@ class ShopsRepositoryTest {
         override fun reportDao() = throw UnsupportedOperationException("テスト対象外")
         override fun createInvalidationTracker(): InvalidationTracker =
             InvalidationTracker(this, emptyMap(), emptyMap())
+        override fun clearAllTables() = Unit
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryTest.kt
@@ -1,0 +1,347 @@
+package dev.seabat.ramennote.data.repository
+
+import androidx.room.InvalidationTracker
+import dev.seabat.ramennote.data.database.RamenNoteDatabase
+import dev.seabat.ramennote.data.database.dao.ShopDao
+import dev.seabat.ramennote.data.database.entity.ShopEntity
+import dev.seabat.ramennote.domain.model.Shop
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ShopsRepositoryTest {
+
+    // --- getAllShops ---
+
+    @Test
+    fun `getAllShops - DAOが返したエンティティをドメインモデルに変換して返す`() = runTest {
+        val entities =
+            listOf(
+                createEntity(id = 1, name = "麺屋東京", areaId = 1),
+                createEntity(id = 2, name = "らーめん大阪", areaId = 2)
+            )
+        val repository = buildRepository(FakeShopDao(entities.toMutableList()))
+
+        val result = repository.getAllShops()
+
+        assertEquals(2, result.size)
+        assertEquals(1, result[0].id)
+        assertEquals("麺屋東京", result[0].name)
+        assertEquals(1, result[0].areaId)
+        assertEquals(2, result[1].id)
+        assertEquals("らーめん大阪", result[1].name)
+    }
+
+    @Test
+    fun `getAllShops - DAOがエンティティを返さない場合は空リストを返す`() = runTest {
+        val repository = buildRepository(FakeShopDao())
+
+        val result = repository.getAllShops()
+
+        assertTrue(result.isEmpty())
+    }
+
+    // --- getAllShopsFlow ---
+
+    @Test
+    fun `getAllShopsFlow - Flowでエンティティをドメインモデルに変換して返す`() = runTest {
+        val entities =
+            listOf(
+                createEntity(id = 1, name = "麺屋東京", areaId = 1),
+                createEntity(id = 2, name = "らーめん大阪", areaId = 2)
+            )
+        val repository = buildRepository(FakeShopDao(entities.toMutableList()))
+
+        val result = repository.getAllShopsFlow().first()
+
+        assertEquals(2, result.size)
+        assertEquals("麺屋東京", result[0].name)
+        assertEquals("らーめん大阪", result[1].name)
+    }
+
+    // --- getShopById ---
+
+    @Test
+    fun `getShopById - 一致する店舗をドメインモデルに変換して返す`() = runTest {
+        val entity = createEntity(id = 42, name = "福岡ラーメン", areaId = 3)
+        val repository = buildRepository(FakeShopDao(mutableListOf(entity)))
+
+        val result = repository.getShopById(42)
+
+        assertNotNull(result)
+        assertEquals(42, result.id)
+        assertEquals("福岡ラーメン", result.name)
+        assertEquals(3, result.areaId)
+    }
+
+    @Test
+    fun `getShopById - 一致するIDがない場合はnullを返す`() = runTest {
+        val repository = buildRepository(FakeShopDao())
+
+        val result = repository.getShopById(999)
+
+        assertNull(result)
+    }
+
+    // --- getShopsByAreaId ---
+
+    @Test
+    fun `getShopsByAreaId - areaIdが一致する店舗リストを返す`() = runTest {
+        val entities =
+            listOf(
+                createEntity(id = 1, name = "東京A", areaId = 1),
+                createEntity(id = 2, name = "東京B", areaId = 1),
+                createEntity(id = 3, name = "大阪A", areaId = 2)
+            )
+        val repository = buildRepository(FakeShopDao(entities.toMutableList()))
+
+        val result = repository.getShopsByAreaId(1)
+
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.areaId == 1 })
+    }
+
+    @Test
+    fun `getShopsByAreaId - 一致するエリアがない場合は空リストを返す`() = runTest {
+        val repository = buildRepository(FakeShopDao())
+
+        val result = repository.getShopsByAreaId(99)
+
+        assertTrue(result.isEmpty())
+    }
+
+    // --- insertShop ---
+
+    @Test
+    fun `insertShop - ドメインモデルをエンティティに変換してDAOに渡す`() = runTest {
+        val dao = FakeShopDao()
+        val repository = buildRepository(dao)
+        val shop = createShop(id = 10, name = "新規店舗", areaId = 2)
+
+        repository.insertShop(shop)
+
+        val inserted = dao.insertedShop
+        assertNotNull(inserted)
+        assertEquals(10, inserted.id)
+        assertEquals("新規店舗", inserted.name)
+        assertEquals(2, inserted.areaId)
+    }
+
+    // --- updateShop ---
+
+    @Test
+    fun `updateShop - ドメインモデルをエンティティに変換してDAOに渡す`() = runTest {
+        val entity = createEntity(id = 5, name = "旧店名", areaId = 1)
+        val dao = FakeShopDao(mutableListOf(entity))
+        val repository = buildRepository(dao)
+        val shop = createShop(id = 5, name = "新店名", areaId = 1)
+
+        repository.updateShop(shop)
+
+        assertEquals("新店名", dao.updatedShop?.name)
+        assertEquals(5, dao.updatedShop?.id)
+    }
+
+    // --- deleteShop ---
+
+    @Test
+    fun `deleteShop - ドメインモデルをエンティティに変換してDAOに渡す`() = runTest {
+        val entity = createEntity(id = 7, name = "削除対象店", areaId = 1)
+        val dao = FakeShopDao(mutableListOf(entity))
+        val repository = buildRepository(dao)
+        val shop = createShop(id = 7, name = "削除対象店", areaId = 1)
+
+        repository.deleteShop(shop)
+
+        assertEquals(7, dao.deletedShop?.id)
+    }
+
+    // --- deleteShopById ---
+
+    @Test
+    fun `deleteShopById - IDがDAOに渡される`() = runTest {
+        val entity = createEntity(id = 3, name = "削除店", areaId = 1)
+        val dao = FakeShopDao(mutableListOf(entity))
+        val repository = buildRepository(dao)
+
+        repository.deleteShopById(3)
+
+        assertEquals(3, dao.deletedById)
+    }
+
+    // --- getShopsByName ---
+
+    @Test
+    fun `getShopsByName - クエリに一致する店舗リストを返す`() = runTest {
+        val entities =
+            listOf(
+                createEntity(id = 1, name = "東京ラーメン", areaId = 1),
+                createEntity(id = 2, name = "大阪つけ麺", areaId = 2),
+                createEntity(id = 3, name = "東京つけ麺", areaId = 1)
+            )
+        val repository = buildRepository(FakeShopDao(entities.toMutableList()))
+
+        val result = repository.getShopsByName("東京")
+
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.name.contains("東京") })
+    }
+
+    @Test
+    fun `getShopsByName - クエリに一致する店舗がない場合は空リストを返す`() = runTest {
+        val repository = buildRepository(FakeShopDao())
+
+        val result = repository.getShopsByName("存在しない")
+
+        assertTrue(result.isEmpty())
+    }
+
+    // --- Entity ↔ Domain 変換 ---
+
+    @Test
+    fun `toDomainModel - scheduledDateが空文字の場合はnullに変換される`() = runTest {
+        val entity = createEntity(id = 1, scheduledDate = "")
+        val repository = buildRepository(FakeShopDao(mutableListOf(entity)))
+
+        val result = repository.getShopById(1)
+
+        assertNull(result?.scheduledDate)
+    }
+
+    @Test
+    fun `toDomainModel - scheduledDateが日付文字列の場合はLocalDateに変換される`() = runTest {
+        val entity = createEntity(id = 1, scheduledDate = "2024-09-15")
+        val repository = buildRepository(FakeShopDao(mutableListOf(entity)))
+
+        val result = repository.getShopById(1)
+
+        assertEquals(LocalDate.parse("2024-09-15"), result?.scheduledDate)
+    }
+
+    @Test
+    fun `toEntity - scheduledDateがnullの場合は空文字に変換される`() = runTest {
+        val dao = FakeShopDao()
+        val repository = buildRepository(dao)
+        val shop = createShop(id = 1, scheduledDate = null)
+
+        repository.insertShop(shop)
+
+        assertEquals("", dao.insertedShop?.scheduledDate)
+    }
+
+    @Test
+    fun `toEntity - scheduledDateがLocalDateの場合は文字列に変換される`() = runTest {
+        val dao = FakeShopDao()
+        val repository = buildRepository(dao)
+        val shop = createShop(id = 1, scheduledDate = LocalDate.parse("2024-09-15"))
+
+        repository.insertShop(shop)
+
+        assertEquals("2024-09-15", dao.insertedShop?.scheduledDate)
+    }
+
+    // --- ヘルパー ---
+
+    private fun buildRepository(dao: FakeShopDao): ShopsRepository =
+        ShopsRepository(FakeRamenNoteDatabase(dao))
+
+    private fun createEntity(
+        id: Int = 1,
+        name: String = "テスト店",
+        areaId: Int = 1,
+        scheduledDate: String = ""
+    ) = ShopEntity(
+        id = id,
+        name = name,
+        areaId = areaId,
+        shopUrl = "",
+        mapUrl = "",
+        star = 0,
+        stationName = "",
+        category = "",
+        scheduledDate = scheduledDate,
+        menuName1 = "",
+        menuName2 = "",
+        menuName3 = "",
+        photoName1 = "",
+        photoName2 = "",
+        photoName3 = "",
+        description1 = "",
+        description2 = "",
+        description3 = "",
+        favorite = false,
+        note = ""
+    )
+
+    private fun createShop(
+        id: Int = 1,
+        name: String = "テスト店",
+        areaId: Int = 1,
+        scheduledDate: LocalDate? = null
+    ) = Shop(
+        id = id,
+        name = name,
+        areaId = areaId,
+        scheduledDate = scheduledDate
+    )
+
+    // --- フェイク実装 ---
+
+    private class FakeShopDao(
+        private val shops: MutableList<ShopEntity> = mutableListOf()
+    ) : ShopDao {
+        var insertedShop: ShopEntity? = null
+        var updatedShop: ShopEntity? = null
+        var deletedShop: ShopEntity? = null
+        var deletedById: Int? = null
+
+        override suspend fun getAllShops(): List<ShopEntity> = shops
+
+        override fun getAllShopsFlow(): Flow<List<ShopEntity>> = flowOf(shops)
+
+        override suspend fun getShopById(id: Int): ShopEntity? =
+            shops.find { it.id == id }
+
+        override suspend fun getShopsByAreaId(areaId: Int): List<ShopEntity> =
+            shops.filter { it.areaId == areaId }
+
+        override suspend fun insertShop(shop: ShopEntity) {
+            insertedShop = shop
+            shops.add(shop)
+        }
+
+        override suspend fun updateShop(shop: ShopEntity) {
+            updatedShop = shop
+            val index = shops.indexOfFirst { it.id == shop.id }
+            if (index >= 0) shops[index] = shop
+        }
+
+        override suspend fun deleteShop(shop: ShopEntity) {
+            deletedShop = shop
+            shops.removeAll { it.id == shop.id }
+        }
+
+        override suspend fun deleteShopById(id: Int) {
+            deletedById = id
+            shops.removeAll { it.id == id }
+        }
+
+        override suspend fun searchShopsByName(query: String): List<ShopEntity> =
+            shops.filter { it.name.contains(query) }
+    }
+
+    private class FakeRamenNoteDatabase(private val dao: FakeShopDao) : RamenNoteDatabase() {
+        override fun areaDao() = throw UnsupportedOperationException("テスト対象外")
+        override fun shopDao() = dao
+        override fun reportDao() = throw UnsupportedOperationException("テスト対象外")
+        override fun createInvalidationTracker(): InvalidationTracker =
+            InvalidationTracker(this, emptyMap(), emptyMap())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCaseTest.kt
@@ -1,0 +1,234 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.Report
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.model.Shop
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DeleteShopAndImageUseCaseTest {
+
+    private val fakeShopsRepository = FakeShopsRepository()
+    private val fakeLocalImageRepository = FakeLocalImageRepository()
+    private val fakeUpdateShopCountInAreaUseCase = FakeUpdateShopCountInAreaUseCase()
+    private val fakeReportsRepository = FakeReportsRepository()
+
+    private val useCase = DeleteShopAndImageUseCase(
+        shopsRepository = fakeShopsRepository,
+        localAreaImageRepository = fakeLocalImageRepository,
+        updateShopCountInAreaUseCase = fakeUpdateShopCountInAreaUseCase,
+        reportsRepository = fakeReportsRepository
+    )
+
+    // --- 成功ケース ---
+
+    @Test
+    fun `invoke - 成功時にRunStatus_Successを返す`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10)
+
+        val result = useCase(1)
+
+        assertIs<RunStatus.Success<String>>(result)
+    }
+
+    @Test
+    fun `invoke - Shopが存在する場合にreports削除が呼ばれる`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10)
+
+        useCase(1)
+
+        assertEquals(1, fakeReportsRepository.deletedByShopId)
+    }
+
+    @Test
+    fun `invoke - Shopが存在する場合にshop削除が呼ばれる`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10)
+
+        useCase(1)
+
+        assertEquals(1, fakeShopsRepository.deletedShopId)
+    }
+
+    @Test
+    fun `invoke - reports削除はshop削除より先に呼ばれる`() = runTest {
+        val callOrder = mutableListOf<String>()
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10)
+        fakeReportsRepository.onDeleteByShopId = { callOrder.add("reports") }
+        fakeShopsRepository.onDeleteShopById = { callOrder.add("shop") }
+
+        useCase(1)
+
+        assertEquals(listOf("reports", "shop"), callOrder)
+    }
+
+    @Test
+    fun `invoke - photoName1が空でない場合に画像削除が呼ばれる`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10, photoName1 = "photo1.jpg")
+
+        useCase(1)
+
+        assertTrue(fakeLocalImageRepository.deletedNames.contains("photo1.jpg"))
+    }
+
+    @Test
+    fun `invoke - photoName1が空の場合に画像削除が呼ばれない`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10, photoName1 = "")
+
+        useCase(1)
+
+        assertTrue(fakeLocalImageRepository.deletedNames.isEmpty())
+    }
+
+    @Test
+    fun `invoke - 3枚の画像がすべて削除される`() = runTest {
+        fakeShopsRepository.shop = createTestShop(
+            id = 1,
+            areaId = 10,
+            photoName1 = "p1.jpg",
+            photoName2 = "p2.jpg",
+            photoName3 = "p3.jpg"
+        )
+
+        useCase(1)
+
+        assertEquals(listOf("p1.jpg", "p2.jpg", "p3.jpg"), fakeLocalImageRepository.deletedNames)
+    }
+
+    @Test
+    fun `invoke - 成功時にshopCountInAreaの更新が呼ばれる`() = runTest {
+        fakeShopsRepository.shop = createTestShop(id = 1, areaId = 10)
+
+        useCase(1)
+
+        assertEquals(10, fakeUpdateShopCountInAreaUseCase.invokedAreaId)
+    }
+
+    // --- Shopが存在しない場合 ---
+
+    @Test
+    fun `invoke - Shopが存在しない場合もRunStatus_Successを返す`() = runTest {
+        fakeShopsRepository.shop = null
+
+        val result = useCase(999)
+
+        assertIs<RunStatus.Success<String>>(result)
+    }
+
+    @Test
+    fun `invoke - Shopが存在しない場合はreports削除が呼ばれない`() = runTest {
+        fakeShopsRepository.shop = null
+
+        useCase(999)
+
+        assertNull(fakeReportsRepository.deletedByShopId)
+    }
+
+    @Test
+    fun `invoke - Shopが存在しない場合はshopCountInAreaの更新が呼ばれない`() = runTest {
+        fakeShopsRepository.shop = null
+
+        useCase(999)
+
+        assertNull(fakeUpdateShopCountInAreaUseCase.invokedAreaId)
+    }
+
+    // --- 例外発生 ---
+
+    @Test
+    fun `invoke - 例外発生時にRunStatus_Errorを返す`() = runTest {
+        fakeShopsRepository.throwOnGetShopById = true
+
+        val result = useCase(1)
+
+        assertIs<RunStatus.Error<String>>(result)
+    }
+
+    // --- ヘルパー ---
+
+    private fun createTestShop(
+        id: Int,
+        areaId: Int,
+        photoName1: String = "",
+        photoName2: String = "",
+        photoName3: String = ""
+    ) = Shop(
+        id = id,
+        areaId = areaId,
+        photoName1 = photoName1,
+        photoName2 = photoName2,
+        photoName3 = photoName3
+    )
+
+    // --- フェイク実装 ---
+
+    private class FakeShopsRepository : ShopsRepositoryContract {
+        var shop: Shop? = null
+        var deletedShopId: Int? = null
+        var throwOnGetShopById = false
+        var onDeleteShopById: (() -> Unit)? = null
+
+        override suspend fun getShopById(id: Int): Shop? {
+            if (throwOnGetShopById) throw RuntimeException("テスト用例外")
+            return shop
+        }
+
+        override suspend fun deleteShopById(id: Int) {
+            onDeleteShopById?.invoke()
+            deletedShopId = id
+        }
+
+        override suspend fun getAllShops(): List<Shop> = emptyList()
+        override fun getAllShopsFlow(): Flow<List<Shop>> = flowOf(emptyList())
+        override suspend fun getShopsByAreaId(areaId: Int): List<Shop> = emptyList()
+        override suspend fun insertShop(shop: Shop) = Unit
+        override suspend fun updateShop(shop: Shop) = Unit
+        override suspend fun deleteShop(shop: Shop) = Unit
+        override suspend fun getShopsByName(query: String): List<Shop> = emptyList()
+    }
+
+    private class FakeLocalImageRepository : LocalImageRepositoryContract {
+        val deletedNames = mutableListOf<String>()
+
+        override suspend fun delete(name: String) {
+            deletedNames.add(name)
+        }
+
+        override suspend fun save(imageBytes: ByteArray, name: String) = Unit
+        override suspend fun load(name: String): RunStatus<ByteArray> = RunStatus.Error("未実装")
+        override suspend fun rename(oldName: String, newName: String) = Unit
+    }
+
+    private class FakeUpdateShopCountInAreaUseCase : UpdateShopCountInAreaUseCaseContract {
+        var invokedAreaId: Int? = null
+
+        override suspend fun invoke(areaId: Int) {
+            invokedAreaId = areaId
+        }
+    }
+
+    private class FakeReportsRepository : ReportsRepositoryContract {
+        var deletedByShopId: Int? = null
+        var onDeleteByShopId: (() -> Unit)? = null
+
+        override suspend fun deleteByShopId(shopId: Int) {
+            onDeleteByShopId?.invoke()
+            deletedByShopId = shopId
+        }
+
+        override suspend fun load(): List<Report> = emptyList()
+        override suspend fun insert(report: Report) = Unit
+        override suspend fun loadById(id: Int): Report? = null
+        override suspend fun update(report: Report) = Unit
+        override suspend fun delete(id: Int) = Unit
+        override suspend fun loadByAreaId(areaId: Int): List<Report> = emptyList()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportViewModelTest.kt
@@ -1,0 +1,245 @@
+package dev.seabat.ramennote.ui.screens.history.addreport
+
+import dev.seabat.ramennote.domain.model.Report
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.AddReportUseCaseContract
+import dev.seabat.ramennote.domain.usecase.CreateReportPhotoNameUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.LocalDate
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddReportViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fakeCreateReportPhotoNameUseCase = FakeCreateReportPhotoNameUseCase()
+    private val fakeAddReportUseCase = FakeAddReportUseCase()
+    private val fakeLoadShopUseCase = FakeLoadShopUseCase()
+
+    private lateinit var viewModel: AddReportViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel =
+            AddReportViewModel(
+                createReportPhotoNameUseCase = fakeCreateReportPhotoNameUseCase,
+                addReportUseCase = fakeAddReportUseCase,
+                loadShopUseCase = fakeLoadShopUseCase
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- 初期状態 ---
+
+    @Test
+    fun `reportedStatus - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<Int>>(viewModel.reportedStatus.value)
+    }
+
+    // --- report ---
+
+    @Test
+    fun `report - 成功時にreportedStatusがSuccessになる`() = runTest {
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "醤油らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "美味しかった",
+            shopId = 1,
+            image = null,
+            star = 4
+        )
+
+        assertIs<RunStatus.Success<Int>>(viewModel.reportedStatus.value)
+        assertEquals(1, (viewModel.reportedStatus.value as RunStatus.Success).data)
+    }
+
+    @Test
+    fun `report - addReportUseCaseに正しいReportが渡される`() = runTest {
+        fakeCreateReportPhotoNameUseCase.result = "photo_001.jpg"
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "つけ麺",
+            reportedDate = LocalDate(2024, 9, 15),
+            impression = "麺が太くて美味",
+            shopId = 5,
+            image = null,
+            star = 5
+        )
+
+        val report = fakeAddReportUseCase.invokedReport
+        assertEquals(0, report?.id) // id は後で更新される
+        assertEquals(5, report?.shopId)
+        assertEquals("つけ麺", report?.menuName)
+        assertEquals("photo_001.jpg", report?.photoName)
+        assertEquals("麺が太くて美味", report?.impression)
+        assertEquals(LocalDate(2024, 9, 15), report?.date)
+        assertEquals(5, report?.star)
+    }
+
+    @Test
+    fun `report - shopIdからareaIdを取得してReportにセットする`() = runTest {
+        fakeLoadShopUseCase.result = Shop(id = 3, name = "テスト店", areaId = 7)
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "塩らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 3,
+            image = null,
+            star = 3
+        )
+
+        assertEquals(7, fakeAddReportUseCase.invokedReport?.areaId)
+    }
+
+    @Test
+    fun `report - shopが見つからない場合はareaIdが0になる`() = runTest {
+        fakeLoadShopUseCase.result = null
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "味噌らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 99,
+            image = null,
+            star = 3
+        )
+
+        assertEquals(0, fakeAddReportUseCase.invokedReport?.areaId)
+    }
+
+    @Test
+    fun `report - addReportUseCaseがErrorを返した場合reportedStatusがErrorになる`() = runTest {
+        fakeAddReportUseCase.result = RunStatus.Error("保存失敗")
+
+        viewModel.report(
+            menuName = "らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 1,
+            image = null,
+            star = 3
+        )
+
+        val state = viewModel.reportedStatus.value
+        assertIs<RunStatus.Error<Int>>(state)
+        assertEquals("保存失敗", state.message)
+    }
+
+    @Test
+    fun `report - UseCaseが例外をスローした場合reportedStatusがErrorになる`() = runTest {
+        fakeAddReportUseCase.shouldThrow = true
+
+        viewModel.report(
+            menuName = "らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 1,
+            image = null,
+            star = 3
+        )
+
+        assertIs<RunStatus.Error<Int>>(viewModel.reportedStatus.value)
+    }
+
+    @Test
+    fun `report - imageがnullの場合addReportUseCaseにnullが渡される`() = runTest {
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 1,
+            image = null,
+            star = 3
+        )
+
+        assertEquals(null, fakeAddReportUseCase.invokedImageBytes)
+    }
+
+    @Test
+    fun `report - createReportPhotoNameUseCaseが返すphotoNameがReportに使われる`() = runTest {
+        fakeCreateReportPhotoNameUseCase.result = "unique_photo_name.jpg"
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+
+        viewModel.report(
+            menuName = "らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 1,
+            image = null,
+            star = 3
+        )
+
+        assertEquals("unique_photo_name.jpg", fakeAddReportUseCase.invokedReport?.photoName)
+    }
+
+    // --- setReportedStatusToIdle ---
+
+    @Test
+    fun `setReportedStatusToIdle - reportedStatusがIdleに戻る`() = runTest {
+        fakeAddReportUseCase.result = RunStatus.Success(1)
+        viewModel.report(
+            menuName = "らーめん",
+            reportedDate = LocalDate(2024, 9, 1),
+            impression = "",
+            shopId = 1,
+            image = null,
+            star = 3
+        )
+        assertIs<RunStatus.Success<Int>>(viewModel.reportedStatus.value)
+
+        viewModel.setReportedStatusToIdle()
+
+        assertIs<RunStatus.Idle<Int>>(viewModel.reportedStatus.value)
+    }
+
+    // --- フェイク UseCase 実装 ---
+
+    private class FakeCreateReportPhotoNameUseCase : CreateReportPhotoNameUseCaseContract {
+        var result: String = "photo.jpg"
+        override fun invoke(): String = result
+    }
+
+    private class FakeAddReportUseCase : AddReportUseCaseContract {
+        var invokedReport: Report? = null
+        var invokedImageBytes: ByteArray? = null
+        var result: RunStatus<Int> = RunStatus.Success(1)
+        var shouldThrow = false
+
+        override suspend fun invoke(report: Report, imageBytes: ByteArray?): RunStatus<Int> {
+            if (shouldThrow) throw RuntimeException("保存エラー")
+            invokedReport = report
+            invokedImageBytes = imageBytes
+            return result
+        }
+    }
+
+    private class FakeLoadShopUseCase : LoadShopUseCaseContract {
+        var result: Shop? = Shop(id = 1, name = "テスト店", areaId = 1)
+        override suspend fun invoke(id: Int): Shop? = result
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaViewModelTest.kt
@@ -1,0 +1,139 @@
+package dev.seabat.ramennote.ui.screens.note.addarea
+
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCaseContract
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddAreaViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fakeAreasRepository = FakeAreasRepository()
+    private val fakeFetchUnsplashImageUseCase = FakeFetchAndSaveUnsplashImageUseCase()
+
+    private lateinit var viewModel: AddAreaViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = AddAreaViewModel(
+            areasRepository = fakeAreasRepository,
+            fetchUnsplashImageUseCase = fakeFetchUnsplashImageUseCase
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- addState 初期状態 ---
+
+    @Test
+    fun `addState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<ByteArray>>(viewModel.addState.value)
+    }
+
+    // --- addArea ---
+
+    @Test
+    fun `addArea - 成功時にaddStateがSuccessになる`() = runTest {
+        val imageBytes = byteArrayOf(1, 2, 3)
+        fakeFetchUnsplashImageUseCase.result = RunStatus.Success(imageBytes)
+
+        viewModel.addArea("東京")
+
+        val state = viewModel.addState.value
+        assertIs<RunStatus.Success<ByteArray>>(state)
+        assertEquals(imageBytes, state.data)
+    }
+
+    @Test
+    fun `addArea - areasRepositoryのaddが呼ばれる`() = runTest {
+        fakeFetchUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.addArea("大阪")
+
+        assertEquals("大阪", fakeAreasRepository.addedArea?.name)
+        assertEquals(0, fakeAreasRepository.addedArea?.count)
+    }
+
+    @Test
+    fun `addArea - エリア名の前後スペースがトリムされてaddが呼ばれる`() = runTest {
+        fakeFetchUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.addArea("  福岡  ")
+
+        assertEquals("福岡", fakeAreasRepository.addedArea?.name)
+    }
+
+    @Test
+    fun `addArea - fetchUnsplashImageUseCaseがErrorを返した場合、addStateがErrorになる`() = runTest {
+        fakeFetchUnsplashImageUseCase.result = RunStatus.Error("画像取得失敗")
+
+        viewModel.addArea("京都")
+
+        val state = viewModel.addState.value
+        assertIs<RunStatus.Error<ByteArray>>(state)
+        assertEquals("画像取得失敗", state.message)
+    }
+
+    @Test
+    fun `addArea - fetchUnsplashImageUseCaseに正しいクエリが渡される`() = runTest {
+        fakeFetchUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.addArea("北海道")
+
+        assertEquals("北海道", fakeFetchUnsplashImageUseCase.invokedQuery)
+    }
+
+    // --- フェイク実装 ---
+
+    private class FakeAreasRepository : AreasRepositoryContract {
+        var addedArea: Area? = null
+
+        override suspend fun load(): List<Area> = emptyList()
+        override suspend fun load(areaName: String): Area? = null
+        override suspend fun loadByAreaId(areaId: Int): Area? = null
+
+        override suspend fun add(area: Area) {
+            addedArea = area
+        }
+
+        override suspend fun edit(oldName: String, newName: String): RunStatus<String> =
+            RunStatus.Success("")
+
+        override suspend fun edit(area: Area): RunStatus<String> =
+            RunStatus.Success("")
+
+        override suspend fun editAll(areas: List<Area>): RunStatus<String> =
+            RunStatus.Success("")
+
+        override suspend fun delete(areaName: String): RunStatus<String> =
+            RunStatus.Success("")
+    }
+
+    private class FakeFetchAndSaveUnsplashImageUseCase : FetchAndSaveUnsplashImageUseCaseContract {
+        var invokedQuery: String? = null
+        var result: RunStatus<ByteArray> = RunStatus.Idle()
+
+        override suspend fun invoke(query: String): RunStatus<ByteArray> {
+            invokedQuery = query
+            return result
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
@@ -172,13 +172,23 @@ class EditAreaViewModelTest {
         assertIs<RunStatus.Error<ByteArray>>(viewModel.imageState.value)
     }
 
+    // --- loadAreaName ---
+
+    @Test
+    fun `loadAreaName - areaIdに対応するエリア名がareaNameにセットされる`() = runTest {
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
+
+        viewModel.loadAreaName(1)
+
+        assertEquals("東京", viewModel.areaName.value)
+    }
+
     // --- loadImage ---
 
     @Test
     fun `loadImage - 成功時にimageStateがSuccessになる`() = runTest {
         val imageBytes = byteArrayOf(4, 5, 6)
         fakeLoadAreaImageUseCase.result = RunStatus.Success(imageBytes)
-        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
 
         viewModel.loadImage(1)
 
@@ -190,7 +200,6 @@ class EditAreaViewModelTest {
     @Test
     fun `loadImage - areaIdがUseCaseに渡される`() = runTest {
         fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
-        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 2, name = "大阪"))
 
         viewModel.loadImage(2)
 
@@ -198,19 +207,8 @@ class EditAreaViewModelTest {
     }
 
     @Test
-    fun `loadImage - areaIdに対応するエリア名がareaNameにセットされる`() = runTest {
-        fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
-        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
-
-        viewModel.loadImage(1)
-
-        assertEquals("東京", viewModel.areaName.value)
-    }
-
-    @Test
     fun `loadImage - Errorの場合にimageStateがErrorになる`() = runTest {
         fakeLoadAreaImageUseCase.result = RunStatus.Error("読み込み失敗")
-        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
 
         viewModel.loadImage(1)
 
@@ -222,7 +220,6 @@ class EditAreaViewModelTest {
     @Test
     fun `resetImageState - imageStateがIdleに戻る`() = runTest {
         fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
-        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
         viewModel.loadImage(1)
         assertIs<RunStatus.Success<ByteArray>>(viewModel.imageState.value)
 

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
@@ -1,8 +1,10 @@
 package dev.seabat.ramennote.ui.screens.note.editarea
 
+import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.usecase.DeleteAreaUseCaseContract
-import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreaImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCaseContract
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +27,8 @@ class EditAreaViewModelTest {
     private val fakeDeleteAreaUseCase = FakeDeleteAreaUseCase()
     private val fakeUpdateAreaUseCase = FakeUpdateAreaUseCase()
     private val fakeUpdateAreaImageUseCase = FakeUpdateAreaImageUseCase()
-    private val fakeLoadImageUseCase = FakeLoadImageUseCase()
+    private val fakeLoadAreaImageUseCase = FakeLoadAreaImageUseCase()
+    private val fakeLoadAreasUseCase = FakeLoadAreasUseCase()
 
     private lateinit var viewModel: EditAreaViewModel
 
@@ -37,7 +40,8 @@ class EditAreaViewModelTest {
                 deleteAreaUseCase = fakeDeleteAreaUseCase,
                 updateAreaUseCase = fakeUpdateAreaUseCase,
                 updateAreaImageUseCase = fakeUpdateAreaImageUseCase,
-                loadImageUseCase = fakeLoadImageUseCase
+                loadAreaImageUseCase = fakeLoadAreaImageUseCase,
+                loadAreasUseCase = fakeLoadAreasUseCase
             )
     }
 
@@ -63,45 +67,46 @@ class EditAreaViewModelTest {
         assertIs<RunStatus.Idle<ByteArray>>(viewModel.imageState.value)
     }
 
+    @Test
+    fun `areaName - 初期状態は空文字`() {
+        assertEquals("", viewModel.areaName.value)
+    }
+
     // --- editArea ---
 
     @Test
     fun `editArea - 成功時にeditStateがSuccessになる`() = runTest {
-        viewModel.currentAreaName = "旧名称"
-        fakeUpdateAreaUseCase.result = RunStatus.Success("新名称")
+        fakeUpdateAreaUseCase.result = RunStatus.Success("")
 
-        viewModel.editArea("新名称")
+        viewModel.editArea(1, "新名称")
 
         assertIs<RunStatus.Success<String>>(viewModel.editState.value)
     }
 
     @Test
-    fun `editArea - currentAreaNameとnewAreaNameがUseCaseに渡される`() = runTest {
-        viewModel.currentAreaName = "旧名称"
+    fun `editArea - areaIdとnewAreaNameがUseCaseに渡される`() = runTest {
         fakeUpdateAreaUseCase.result = RunStatus.Success("")
 
-        viewModel.editArea("新名称")
+        viewModel.editArea(1, "新名称")
 
-        assertEquals("旧名称", fakeUpdateAreaUseCase.invokedOldName)
+        assertEquals(1, fakeUpdateAreaUseCase.invokedAreaId)
         assertEquals("新名称", fakeUpdateAreaUseCase.invokedNewName)
     }
 
     @Test
-    fun `editArea - 成功後にcurrentAreaNameが更新される`() = runTest {
-        viewModel.currentAreaName = "旧名称"
+    fun `editArea - 成功後にareaNameが更新される`() = runTest {
         fakeUpdateAreaUseCase.result = RunStatus.Success("")
 
-        viewModel.editArea("新名称")
+        viewModel.editArea(1, "新名称")
 
-        assertEquals("新名称", viewModel.currentAreaName)
+        assertEquals("新名称", viewModel.areaName.value)
     }
 
     @Test
     fun `editArea - Errorの場合にeditStateがErrorになる`() = runTest {
-        viewModel.currentAreaName = "存在しない"
         fakeUpdateAreaUseCase.result = RunStatus.Error("更新失敗")
 
-        viewModel.editArea("新名称")
+        viewModel.editArea(1, "新名称")
 
         assertIs<RunStatus.Error<String>>(viewModel.editState.value)
     }
@@ -112,37 +117,37 @@ class EditAreaViewModelTest {
     fun `deleteArea - 成功時にeditStateがSuccessになる`() = runTest {
         fakeDeleteAreaUseCase.result = RunStatus.Success("")
 
-        viewModel.deleteArea("東京")
+        viewModel.deleteArea(1)
 
         assertIs<RunStatus.Success<String>>(viewModel.editState.value)
     }
 
     @Test
-    fun `deleteArea - areaNameがUseCaseに渡される`() = runTest {
+    fun `deleteArea - areaIdがUseCaseに渡される`() = runTest {
         fakeDeleteAreaUseCase.result = RunStatus.Success("")
 
-        viewModel.deleteArea("大阪")
+        viewModel.deleteArea(2)
 
-        assertEquals("大阪", fakeDeleteAreaUseCase.invokedName)
+        assertEquals(2, fakeDeleteAreaUseCase.invokedAreaId)
     }
 
     @Test
     fun `deleteArea - Errorの場合にeditStateがErrorになる`() = runTest {
         fakeDeleteAreaUseCase.result = RunStatus.Error("削除失敗")
 
-        viewModel.deleteArea("存在しない")
+        viewModel.deleteArea(1)
 
         assertIs<RunStatus.Error<String>>(viewModel.editState.value)
     }
 
-    // --- fetchImage ---
+    // --- fetchNewImage ---
 
     @Test
-    fun `fetchImage - 成功時にimageStateがSuccessになる`() = runTest {
+    fun `fetchNewImage - 成功時にimageStateがSuccessになる`() = runTest {
         val imageBytes = byteArrayOf(1, 2, 3)
         fakeUpdateAreaImageUseCase.result = RunStatus.Success(imageBytes)
 
-        viewModel.fetchImage("東京")
+        viewModel.fetchNewImage(1)
 
         val state = viewModel.imageState.value
         assertIs<RunStatus.Success<ByteArray>>(state)
@@ -150,19 +155,19 @@ class EditAreaViewModelTest {
     }
 
     @Test
-    fun `fetchImage - areaNameがUseCaseに渡される`() = runTest {
+    fun `fetchNewImage - areaIdがUseCaseに渡される`() = runTest {
         fakeUpdateAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
 
-        viewModel.fetchImage("福岡")
+        viewModel.fetchNewImage(3)
 
-        assertEquals("福岡", fakeUpdateAreaImageUseCase.invokedArea)
+        assertEquals(3, fakeUpdateAreaImageUseCase.invokedAreaId)
     }
 
     @Test
-    fun `fetchImage - Errorの場合にimageStateがErrorになる`() = runTest {
+    fun `fetchNewImage - Errorの場合にimageStateがErrorになる`() = runTest {
         fakeUpdateAreaImageUseCase.result = RunStatus.Error("画像取得失敗")
 
-        viewModel.fetchImage("東京")
+        viewModel.fetchNewImage(1)
 
         assertIs<RunStatus.Error<ByteArray>>(viewModel.imageState.value)
     }
@@ -172,9 +177,10 @@ class EditAreaViewModelTest {
     @Test
     fun `loadImage - 成功時にimageStateがSuccessになる`() = runTest {
         val imageBytes = byteArrayOf(4, 5, 6)
-        fakeLoadImageUseCase.result = RunStatus.Success(imageBytes)
+        fakeLoadAreaImageUseCase.result = RunStatus.Success(imageBytes)
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
 
-        viewModel.loadImage("東京")
+        viewModel.loadImage(1)
 
         val state = viewModel.imageState.value
         assertIs<RunStatus.Success<ByteArray>>(state)
@@ -182,19 +188,31 @@ class EditAreaViewModelTest {
     }
 
     @Test
-    fun `loadImage - nameがUseCaseに渡される`() = runTest {
-        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+    fun `loadImage - areaIdがUseCaseに渡される`() = runTest {
+        fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 2, name = "大阪"))
 
-        viewModel.loadImage("大阪")
+        viewModel.loadImage(2)
 
-        assertEquals("大阪", fakeLoadImageUseCase.invokedName)
+        assertEquals(2, fakeLoadAreaImageUseCase.invokedAreaId)
+    }
+
+    @Test
+    fun `loadImage - areaIdに対応するエリア名がareaNameにセットされる`() = runTest {
+        fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
+
+        viewModel.loadImage(1)
+
+        assertEquals("東京", viewModel.areaName.value)
     }
 
     @Test
     fun `loadImage - Errorの場合にimageStateがErrorになる`() = runTest {
-        fakeLoadImageUseCase.result = RunStatus.Error("読み込み失敗")
+        fakeLoadAreaImageUseCase.result = RunStatus.Error("読み込み失敗")
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
 
-        viewModel.loadImage("東京")
+        viewModel.loadImage(1)
 
         assertIs<RunStatus.Error<ByteArray>>(viewModel.imageState.value)
     }
@@ -203,8 +221,9 @@ class EditAreaViewModelTest {
 
     @Test
     fun `resetImageState - imageStateがIdleに戻る`() = runTest {
-        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
-        viewModel.loadImage("東京")
+        fakeLoadAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
+        fakeLoadAreasUseCase.areas = listOf(createTestArea(areaId = 1, name = "東京"))
+        viewModel.loadImage(1)
         assertIs<RunStatus.Success<ByteArray>>(viewModel.imageState.value)
 
         viewModel.resetImageState()
@@ -212,47 +231,63 @@ class EditAreaViewModelTest {
         assertIs<RunStatus.Idle<ByteArray>>(viewModel.imageState.value)
     }
 
+    // --- ヘルパー ---
+
+    private fun createTestArea(areaId: Int, name: String) = Area(
+        areaId = areaId,
+        name = name,
+        count = 0,
+        updatedDate = kotlinx.datetime.LocalDate(2026, 1, 1),
+        sort = 1
+    )
+
     // --- フェイク UseCase 実装 ---
 
     private class FakeDeleteAreaUseCase : DeleteAreaUseCaseContract {
-        var invokedName: String? = null
+        var invokedAreaId: Int? = null
         var result: RunStatus<String> = RunStatus.Success("")
 
-        override suspend fun invoke(name: String): RunStatus<String> {
-            invokedName = name
+        override suspend fun invoke(areaId: Int): RunStatus<String> {
+            invokedAreaId = areaId
             return result
         }
     }
 
     private class FakeUpdateAreaUseCase : UpdateAreaUseCaseContract {
-        var invokedOldName: String? = null
+        var invokedAreaId: Int? = null
         var invokedNewName: String? = null
         var result: RunStatus<String> = RunStatus.Success("")
 
-        override suspend fun invoke(oldName: String, newName: String): RunStatus<String> {
-            invokedOldName = oldName
+        override suspend fun invoke(areaId: Int, newName: String): RunStatus<String> {
+            invokedAreaId = areaId
             invokedNewName = newName
             return result
         }
     }
 
     private class FakeUpdateAreaImageUseCase : UpdateAreaImageUseCaseContract {
-        var invokedArea: String? = null
+        var invokedAreaId: Int? = null
         var result: RunStatus<ByteArray> = RunStatus.Success(byteArrayOf())
 
-        override suspend fun invoke(area: String): RunStatus<ByteArray> {
-            invokedArea = area
+        override suspend fun invoke(areaId: Int): RunStatus<ByteArray> {
+            invokedAreaId = areaId
             return result
         }
     }
 
-    private class FakeLoadImageUseCase : LoadImageUseCaseContract {
-        var invokedName: String? = null
+    private class FakeLoadAreaImageUseCase : LoadAreaImageUseCaseContract {
+        var invokedAreaId: Int? = null
         var result: RunStatus<ByteArray> = RunStatus.Success(byteArrayOf())
 
-        override suspend fun invoke(name: String): RunStatus<ByteArray> {
-            invokedName = name
+        override suspend fun invoke(areaId: Int): RunStatus<ByteArray> {
+            invokedAreaId = areaId
             return result
         }
+    }
+
+    private class FakeLoadAreasUseCase : LoadAreasUseCaseContract {
+        var areas: List<Area> = emptyList()
+
+        override suspend fun invoke(): List<Area> = areas
     }
 }

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelTest.kt
@@ -1,0 +1,258 @@
+package dev.seabat.ramennote.ui.screens.note.editarea
+
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.usecase.DeleteAreaUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.UpdateAreaImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCaseContract
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditAreaViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fakeDeleteAreaUseCase = FakeDeleteAreaUseCase()
+    private val fakeUpdateAreaUseCase = FakeUpdateAreaUseCase()
+    private val fakeUpdateAreaImageUseCase = FakeUpdateAreaImageUseCase()
+    private val fakeLoadImageUseCase = FakeLoadImageUseCase()
+
+    private lateinit var viewModel: EditAreaViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel =
+            EditAreaViewModel(
+                deleteAreaUseCase = fakeDeleteAreaUseCase,
+                updateAreaUseCase = fakeUpdateAreaUseCase,
+                updateAreaImageUseCase = fakeUpdateAreaImageUseCase,
+                loadImageUseCase = fakeLoadImageUseCase
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- 初期状態 ---
+
+    @Test
+    fun `deleteState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<String>>(viewModel.deleteState.value)
+    }
+
+    @Test
+    fun `editState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<String>>(viewModel.editState.value)
+    }
+
+    @Test
+    fun `imageState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<ByteArray>>(viewModel.imageState.value)
+    }
+
+    // --- editArea ---
+
+    @Test
+    fun `editArea - 成功時にeditStateがSuccessになる`() = runTest {
+        viewModel.currentAreaName = "旧名称"
+        fakeUpdateAreaUseCase.result = RunStatus.Success("新名称")
+
+        viewModel.editArea("新名称")
+
+        assertIs<RunStatus.Success<String>>(viewModel.editState.value)
+    }
+
+    @Test
+    fun `editArea - currentAreaNameとnewAreaNameがUseCaseに渡される`() = runTest {
+        viewModel.currentAreaName = "旧名称"
+        fakeUpdateAreaUseCase.result = RunStatus.Success("")
+
+        viewModel.editArea("新名称")
+
+        assertEquals("旧名称", fakeUpdateAreaUseCase.invokedOldName)
+        assertEquals("新名称", fakeUpdateAreaUseCase.invokedNewName)
+    }
+
+    @Test
+    fun `editArea - 成功後にcurrentAreaNameが更新される`() = runTest {
+        viewModel.currentAreaName = "旧名称"
+        fakeUpdateAreaUseCase.result = RunStatus.Success("")
+
+        viewModel.editArea("新名称")
+
+        assertEquals("新名称", viewModel.currentAreaName)
+    }
+
+    @Test
+    fun `editArea - Errorの場合にeditStateがErrorになる`() = runTest {
+        viewModel.currentAreaName = "存在しない"
+        fakeUpdateAreaUseCase.result = RunStatus.Error("更新失敗")
+
+        viewModel.editArea("新名称")
+
+        assertIs<RunStatus.Error<String>>(viewModel.editState.value)
+    }
+
+    // --- deleteArea ---
+
+    @Test
+    fun `deleteArea - 成功時にeditStateがSuccessになる`() = runTest {
+        fakeDeleteAreaUseCase.result = RunStatus.Success("")
+
+        viewModel.deleteArea("東京")
+
+        assertIs<RunStatus.Success<String>>(viewModel.editState.value)
+    }
+
+    @Test
+    fun `deleteArea - areaNameがUseCaseに渡される`() = runTest {
+        fakeDeleteAreaUseCase.result = RunStatus.Success("")
+
+        viewModel.deleteArea("大阪")
+
+        assertEquals("大阪", fakeDeleteAreaUseCase.invokedName)
+    }
+
+    @Test
+    fun `deleteArea - Errorの場合にeditStateがErrorになる`() = runTest {
+        fakeDeleteAreaUseCase.result = RunStatus.Error("削除失敗")
+
+        viewModel.deleteArea("存在しない")
+
+        assertIs<RunStatus.Error<String>>(viewModel.editState.value)
+    }
+
+    // --- fetchImage ---
+
+    @Test
+    fun `fetchImage - 成功時にimageStateがSuccessになる`() = runTest {
+        val imageBytes = byteArrayOf(1, 2, 3)
+        fakeUpdateAreaImageUseCase.result = RunStatus.Success(imageBytes)
+
+        viewModel.fetchImage("東京")
+
+        val state = viewModel.imageState.value
+        assertIs<RunStatus.Success<ByteArray>>(state)
+        assertEquals(imageBytes, state.data)
+    }
+
+    @Test
+    fun `fetchImage - areaNameがUseCaseに渡される`() = runTest {
+        fakeUpdateAreaImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.fetchImage("福岡")
+
+        assertEquals("福岡", fakeUpdateAreaImageUseCase.invokedArea)
+    }
+
+    @Test
+    fun `fetchImage - Errorの場合にimageStateがErrorになる`() = runTest {
+        fakeUpdateAreaImageUseCase.result = RunStatus.Error("画像取得失敗")
+
+        viewModel.fetchImage("東京")
+
+        assertIs<RunStatus.Error<ByteArray>>(viewModel.imageState.value)
+    }
+
+    // --- loadImage ---
+
+    @Test
+    fun `loadImage - 成功時にimageStateがSuccessになる`() = runTest {
+        val imageBytes = byteArrayOf(4, 5, 6)
+        fakeLoadImageUseCase.result = RunStatus.Success(imageBytes)
+
+        viewModel.loadImage("東京")
+
+        val state = viewModel.imageState.value
+        assertIs<RunStatus.Success<ByteArray>>(state)
+        assertEquals(imageBytes, state.data)
+    }
+
+    @Test
+    fun `loadImage - nameがUseCaseに渡される`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.loadImage("大阪")
+
+        assertEquals("大阪", fakeLoadImageUseCase.invokedName)
+    }
+
+    @Test
+    fun `loadImage - Errorの場合にimageStateがErrorになる`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Error("読み込み失敗")
+
+        viewModel.loadImage("東京")
+
+        assertIs<RunStatus.Error<ByteArray>>(viewModel.imageState.value)
+    }
+
+    // --- resetImageState ---
+
+    @Test
+    fun `resetImageState - imageStateがIdleに戻る`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+        viewModel.loadImage("東京")
+        assertIs<RunStatus.Success<ByteArray>>(viewModel.imageState.value)
+
+        viewModel.resetImageState()
+
+        assertIs<RunStatus.Idle<ByteArray>>(viewModel.imageState.value)
+    }
+
+    // --- フェイク UseCase 実装 ---
+
+    private class FakeDeleteAreaUseCase : DeleteAreaUseCaseContract {
+        var invokedName: String? = null
+        var result: RunStatus<String> = RunStatus.Success("")
+
+        override suspend fun invoke(name: String): RunStatus<String> {
+            invokedName = name
+            return result
+        }
+    }
+
+    private class FakeUpdateAreaUseCase : UpdateAreaUseCaseContract {
+        var invokedOldName: String? = null
+        var invokedNewName: String? = null
+        var result: RunStatus<String> = RunStatus.Success("")
+
+        override suspend fun invoke(oldName: String, newName: String): RunStatus<String> {
+            invokedOldName = oldName
+            invokedNewName = newName
+            return result
+        }
+    }
+
+    private class FakeUpdateAreaImageUseCase : UpdateAreaImageUseCaseContract {
+        var invokedArea: String? = null
+        var result: RunStatus<ByteArray> = RunStatus.Success(byteArrayOf())
+
+        override suspend fun invoke(area: String): RunStatus<ByteArray> {
+            invokedArea = area
+            return result
+        }
+    }
+
+    private class FakeLoadImageUseCase : LoadImageUseCaseContract {
+        var invokedName: String? = null
+        var result: RunStatus<ByteArray> = RunStatus.Success(byteArrayOf())
+
+        override suspend fun invoke(name: String): RunStatus<ByteArray> {
+            invokedName = name
+            return result
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelTest.kt
@@ -1,0 +1,303 @@
+package dev.seabat.ramennote.ui.screens.note.editshop
+
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.DeleteShopAndImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.UpdateShopUseCaseContract
+import dev.seabat.ramennote.ui.gallery.SharedImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.LocalDate
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EditShopViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fakeUpdateShopUseCase = FakeUpdateShopUseCase()
+    private val fakeLoadImageUseCase = FakeLoadImageUseCase()
+    private val fakeDeleteShopAndImageUseCase = FakeDeleteShopAndImageUseCase()
+    private val fakeLoadAreasUseCase = FakeLoadAreasUseCase()
+
+    private lateinit var viewModel: EditShopViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel =
+            EditShopViewModel(
+                updateShopUseCase = fakeUpdateShopUseCase,
+                loadImageUseCase = fakeLoadImageUseCase,
+                deleteShopAndImageUseCase = fakeDeleteShopAndImageUseCase,
+                loadAreasUseCase = fakeLoadAreasUseCase
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // --- 初期状態 ---
+
+    @Test
+    fun `saveState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<String>>(viewModel.saveState.value)
+    }
+
+    @Test
+    fun `deleteState - 初期状態はIdle`() {
+        assertIs<RunStatus.Idle<String>>(viewModel.deleteState.value)
+    }
+
+    @Test
+    fun `shopImage - 初期状態はnull`() {
+        assertNull(viewModel.shopImage.value)
+    }
+
+    @Test
+    fun `areasState - 初期状態は空リスト`() {
+        assertEquals(emptyList(), viewModel.areasState.value)
+    }
+
+    // --- loadImage ---
+
+    @Test
+    fun `loadImage - photoName1が空の場合shopImageはnullになる`() = runTest {
+        val shop = createTestShop(photoName1 = "")
+
+        viewModel.loadImage(shop)
+
+        assertNull(viewModel.shopImage.value)
+    }
+
+    @Test
+    fun `loadImage - 画像読み込み成功時はshopImageがnon-nullになる`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf(1, 2, 3))
+        val shop = createTestShop(photoName1 = "photo.jpg")
+
+        viewModel.loadImage(shop)
+
+        assertNotNull(viewModel.shopImage.value)
+    }
+
+    @Test
+    fun `loadImage - 画像読み込みがErrorの場合shopImageはnullになる`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Error("読み込み失敗")
+        val shop = createTestShop(photoName1 = "photo.jpg")
+
+        viewModel.loadImage(shop)
+
+        assertNull(viewModel.shopImage.value)
+    }
+
+    @Test
+    fun `loadImage - photoName1がUseCaseに渡される`() = runTest {
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+        val shop = createTestShop(photoName1 = "ramen.jpg")
+
+        viewModel.loadImage(shop)
+
+        assertEquals("ramen.jpg", fakeLoadImageUseCase.invokedName)
+    }
+
+    // --- setImage ---
+
+    @Test
+    fun `setImage - nullを渡すとshopImageがnullになる`() = runTest {
+        viewModel.setImage(null)
+
+        assertNull(viewModel.shopImage.value)
+    }
+
+    @Test
+    fun `setImage - SharedImageを渡すとshopImageにセットされる`() = runTest {
+        val image = SharedImage()
+
+        viewModel.setImage(image)
+
+        assertEquals(image, viewModel.shopImage.value)
+    }
+
+    // --- updateShop ---
+
+    @Test
+    fun `updateShop - 成功時にsaveStateがSuccessになる`() = runTest {
+        val shop = createTestShop()
+
+        viewModel.updateShop(shop, null, 1)
+
+        assertIs<RunStatus.Success<String>>(viewModel.saveState.value)
+    }
+
+    @Test
+    fun `updateShop - shop・byteArray・oldAreaIdがUseCaseに渡される`() = runTest {
+        val shop = createTestShop(id = 5)
+
+        viewModel.updateShop(shop, null, 3)
+
+        assertEquals(shop, fakeUpdateShopUseCase.invokedShop)
+        assertNull(fakeUpdateShopUseCase.invokedByteArray) // sharedImage = null
+        assertEquals(3, fakeUpdateShopUseCase.invokedOldAreaId)
+    }
+
+    @Test
+    fun `updateShop - UseCaseが例外をスローした場合saveStateがErrorになる`() = runTest {
+        fakeUpdateShopUseCase.shouldThrow = true
+        val shop = createTestShop()
+
+        viewModel.updateShop(shop, null, 1)
+
+        val state = viewModel.saveState.value
+        assertIs<RunStatus.Error<String>>(state)
+        assertNotNull(state.message)
+    }
+
+    // --- deleteShop ---
+
+    @Test
+    fun `deleteShop - 成功時にdeleteStateがSuccessになる`() = runTest {
+        fakeDeleteShopAndImageUseCase.result = RunStatus.Success("")
+
+        viewModel.deleteShop(1)
+
+        assertIs<RunStatus.Success<String>>(viewModel.deleteState.value)
+    }
+
+    @Test
+    fun `deleteShop - shopIdがUseCaseに渡される`() = runTest {
+        fakeDeleteShopAndImageUseCase.result = RunStatus.Success("")
+
+        viewModel.deleteShop(42)
+
+        assertEquals(42, fakeDeleteShopAndImageUseCase.invokedShopId)
+    }
+
+    @Test
+    fun `deleteShop - Errorの場合deleteStateがErrorになる`() = runTest {
+        fakeDeleteShopAndImageUseCase.result = RunStatus.Error("削除失敗")
+
+        viewModel.deleteShop(1)
+
+        assertIs<RunStatus.Error<String>>(viewModel.deleteState.value)
+    }
+
+    // --- setSaveStateToIdle ---
+
+    @Test
+    fun `setSaveStateToIdle - saveStateがIdleに戻る`() = runTest {
+        viewModel.updateShop(createTestShop(), null, 1)
+        assertIs<RunStatus.Success<String>>(viewModel.saveState.value)
+
+        viewModel.setSaveStateToIdle()
+
+        assertIs<RunStatus.Idle<String>>(viewModel.saveState.value)
+    }
+
+    // --- setDeleteStateToIdle ---
+
+    @Test
+    fun `setDeleteStateToIdle - deleteStateがIdleに戻る`() = runTest {
+        fakeDeleteShopAndImageUseCase.result = RunStatus.Success("")
+        viewModel.deleteShop(1)
+        assertIs<RunStatus.Success<String>>(viewModel.deleteState.value)
+
+        viewModel.setDeleteStateToIdle()
+
+        assertIs<RunStatus.Idle<String>>(viewModel.deleteState.value)
+    }
+
+    // --- loadAreas ---
+
+    @Test
+    fun `loadAreas - UseCaseが返したエリアリストがareasStateにセットされる`() = runTest {
+        val areas =
+            listOf(
+                Area(areaId = 1, name = "東京", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 1),
+                Area(areaId = 2, name = "大阪", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 2)
+            )
+        fakeLoadAreasUseCase.result = areas
+
+        viewModel.loadAreas()
+
+        assertEquals(areas, viewModel.areasState.value)
+    }
+
+    @Test
+    fun `loadAreas - UseCaseが空リストを返した場合areasStateは空リストになる`() = runTest {
+        fakeLoadAreasUseCase.result = emptyList()
+
+        viewModel.loadAreas()
+
+        assertEquals(emptyList(), viewModel.areasState.value)
+    }
+
+    // --- ヘルパー ---
+
+    private fun createTestShop(
+        id: Int = 1,
+        name: String = "テスト店",
+        areaId: Int = 1,
+        photoName1: String = ""
+    ) = Shop(
+        id = id,
+        name = name,
+        areaId = areaId,
+        photoName1 = photoName1
+    )
+
+    // --- フェイク UseCase 実装 ---
+
+    private class FakeUpdateShopUseCase : UpdateShopUseCaseContract {
+        var invokedShop: Shop? = null
+        var invokedByteArray: ByteArray? = null
+        var invokedOldAreaId: Int? = null
+        var shouldThrow = false
+
+        override suspend fun invoke(shop: Shop, byteArray: ByteArray?, oldAreaId: Int) {
+            if (shouldThrow) throw RuntimeException("更新エラー")
+            invokedShop = shop
+            invokedByteArray = byteArray
+            invokedOldAreaId = oldAreaId
+        }
+    }
+
+    private class FakeLoadImageUseCase : LoadImageUseCaseContract {
+        var invokedName: String? = null
+        var result: RunStatus<ByteArray> = RunStatus.Idle()
+
+        override suspend fun invoke(name: String): RunStatus<ByteArray> {
+            invokedName = name
+            return result
+        }
+    }
+
+    private class FakeDeleteShopAndImageUseCase : DeleteShopAndImageUseCaseContract {
+        var invokedShopId: Int? = null
+        var result: RunStatus<String> = RunStatus.Success("")
+
+        override suspend fun invoke(shopId: Int): RunStatus<String> {
+            invokedShopId = shopId
+            return result
+        }
+    }
+
+    private class FakeLoadAreasUseCase : LoadAreasUseCaseContract {
+        var result: List<Area> = emptyList()
+        override suspend fun invoke(): List<Area> = result
+    }
+}

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopViewModelTest.kt
@@ -85,15 +85,8 @@ class EditShopViewModelTest {
         assertNull(viewModel.shopImage.value)
     }
 
-    @Test
-    fun `loadImage - 画像読み込み成功時はshopImageがnon-nullになる`() = runTest {
-        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf(1, 2, 3))
-        val shop = createTestShop(photoName1 = "photo.jpg")
-
-        viewModel.loadImage(shop)
-
-        assertNotNull(viewModel.shopImage.value)
-    }
+    // NOTE: SharedImage(ByteArray) は BitmapFactory を使用するため JVM 単体テストでは実行不可。
+    // 画像ロード成功時の shopImage non-null は instrumented test で検証する。
 
     @Test
     fun `loadImage - 画像読み込みがErrorの場合shopImageはnullになる`() = runTest {
@@ -107,7 +100,8 @@ class EditShopViewModelTest {
 
     @Test
     fun `loadImage - photoName1がUseCaseに渡される`() = runTest {
-        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+        // SharedImage(ByteArray) は BitmapFactory を使用するため Error を返すフェイクで UseCase 呼び出しだけ検証する
+        fakeLoadImageUseCase.result = RunStatus.Error("テスト用エラー")
         val shop = createTestShop(photoName1 = "ramen.jpg")
 
         viewModel.loadImage(shop)

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopViewModelTest.kt
@@ -1,7 +1,9 @@
 package dev.seabat.ramennote.ui.screens.note.shop
 
+import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SwitchFavoriteUseCaseContract
@@ -25,25 +27,27 @@ class ShopViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    // フェイク UseCase
     private val fakeLoadShopUseCase = FakeLoadShopUseCase()
     private val fakeLoadImageUseCase = FakeLoadImageUseCase()
     private val fakeUpdateScheduleUseCase = FakeUpdateScheduleInShopUseCase()
     private val fakeSwitchFavoriteUseCase = FakeSwitchFavoriteUseCase()
     private val fakeUpdateStarUseCase = FakeUpdateStarUseCase()
+    private val fakeLoadAreasUseCase = FakeLoadAreasUseCase()
 
     private lateinit var viewModel: ShopViewModel
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = ShopViewModel(
-            loadShopUseCase = fakeLoadShopUseCase,
-            loadImageUseCase = fakeLoadImageUseCase,
-            addScheduleUseCase = fakeUpdateScheduleUseCase,
-            switchFavoriteUseCase = fakeSwitchFavoriteUseCase,
-            updateStarUseCase = fakeUpdateStarUseCase
-        )
+        viewModel =
+            ShopViewModel(
+                loadShopUseCase = fakeLoadShopUseCase,
+                loadImageUseCase = fakeLoadImageUseCase,
+                addScheduleUseCase = fakeUpdateScheduleUseCase,
+                switchFavoriteUseCase = fakeSwitchFavoriteUseCase,
+                updateStarUseCase = fakeUpdateStarUseCase,
+                loadAreasUseCase = fakeLoadAreasUseCase
+            )
     }
 
     @AfterTest
@@ -111,13 +115,49 @@ class ShopViewModelTest {
         assertNull(viewModel.shopImage.value)
     }
 
+    @Test
+    fun `loadShopAndImage - ShopのareaIdに対応するエリア名がareaNameにセットされる`() = runTest {
+        val shop = createTestShop(areaId = 2)
+        fakeLoadShopUseCase.result = shop
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+        fakeLoadAreasUseCase.result =
+            listOf(
+                Area(areaId = 1, name = "東京", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 1),
+                Area(areaId = 2, name = "大阪", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 2)
+            )
+
+        viewModel.loadShopAndImage(1)
+
+        assertEquals("大阪", viewModel.areaName.value)
+    }
+
+    @Test
+    fun `loadShopAndImage - areaIdに一致するエリアがない場合はareaNameが空文字になる`() = runTest {
+        val shop = createTestShop(areaId = 99)
+        fakeLoadShopUseCase.result = shop
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        viewModel.loadShopAndImage(1)
+
+        assertEquals("", viewModel.areaName.value)
+    }
+
+    @Test
+    fun `loadShopAndImage - Shopがnullの場合はareaNameが更新されない`() = runTest {
+        fakeLoadShopUseCase.result = null
+
+        viewModel.loadShopAndImage(1)
+
+        assertEquals("", viewModel.areaName.value)
+    }
+
     // --- addSchedule ---
 
     @Test
     fun `addSchedule - スケジュール追加後にShopデータを再読み込みする`() = runTest {
         val shop = createTestShop()
         fakeLoadShopUseCase.result = shop
-        fakeLoadImageUseCase.result = RunStatus.Success(null)
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
         val date = LocalDate(2026, 2, 14)
 
         viewModel.addSchedule(1, date)
@@ -134,7 +174,7 @@ class ShopViewModelTest {
     fun `switchFavorite - お気に入り切り替え後にShopデータを再読み込みする`() = runTest {
         val shop = createTestShop()
         fakeLoadShopUseCase.result = shop
-        fakeLoadImageUseCase.result = RunStatus.Success(null)
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
 
         viewModel.switchFavorite(true, 1)
 
@@ -149,7 +189,7 @@ class ShopViewModelTest {
     fun `updateStar - 星評価更新後にShopデータを再読み込みする`() = runTest {
         val shop = createTestShop()
         fakeLoadShopUseCase.result = shop
-        fakeLoadImageUseCase.result = RunStatus.Success(null)
+        fakeLoadImageUseCase.result = RunStatus.Success(byteArrayOf())
 
         viewModel.updateStar(3, 1)
 
@@ -163,11 +203,12 @@ class ShopViewModelTest {
     private fun createTestShop(
         id: Int = 1,
         name: String = "テスト店",
+        areaId: Int = 1,
         photoName1: String = ""
     ) = Shop(
         id = id,
         name = name,
-        area = "東京",
+        areaId = areaId,
         photoName1 = photoName1
     )
 
@@ -179,8 +220,8 @@ class ShopViewModelTest {
     }
 
     private class FakeLoadImageUseCase : LoadImageUseCaseContract {
-        var result: RunStatus<ByteArray?> = RunStatus.Idle()
-        override suspend fun invoke(name: String): RunStatus<ByteArray?> = result
+        var result: RunStatus<ByteArray> = RunStatus.Idle()
+        override suspend fun invoke(name: String): RunStatus<ByteArray> = result
     }
 
     private class FakeUpdateScheduleInShopUseCase : UpdateScheduleInShopUseCaseContract {
@@ -208,5 +249,13 @@ class ShopViewModelTest {
             invokedShopId = shopId
             invokedStar = star
         }
+    }
+
+    private class FakeLoadAreasUseCase : LoadAreasUseCaseContract {
+        var result: List<Area> =
+            listOf(
+                Area(areaId = 1, name = "東京", count = 0, updatedDate = LocalDate(2024, 1, 1), sort = 1)
+            )
+        override suspend fun invoke(): List<Area> = result
     }
 }


### PR DESCRIPTION
### 概要

エリア別にレポートを一覧表示する機能を追加し、エリア・店舗削除時のカスケード削除バグを修正した。

### 主な変更点

**1. エリア別レポート一覧機能**
- エリア別・店舗別のレポート一覧取得 UseCase を追加（`LoadFullReportsByAreaUseCase`、`LoadFullReportsByShopUseCase`）
- エリア画像読み込み UseCase を追加（`LoadAreaImageUseCase`）
- HistoryScreen でエリア別レポート一覧を表示できるよう対応
- `FullReport` モデルに `areaId` フィールドを追加
- MainNavigation にエリア別レポート一覧へのルーティングを追加

**2. バグ修正**
- エリア削除時に関連店舗が削除されないバグを修正
- 店舗削除時に関連レポートが削除されないバグを修正
- `AddShopScreen` のエラーダイアログが確認後に閉じないバグを修正
- `DeleteAreaUseCase` に店舗が存在する場合のエラーチェックを追加

**3. リファクタリング**
- エリア関連 UseCase の引数を `areaName` から `areaId` に変更
- `EditAreaViewModel` の `loadImage` 関数を `loadAreaName` と `loadImage` に分離
- `ShopScreen` からボタンコンポーネントを独立ファイルに抽出（`AddReportButton`、`EditShopButton`、`ScheduleButton`、`ReportListButton`）
- `NoteScreen` の IconButton を `ReportListButton` コンポーネントに置き換え

**4. テスト追加**
- `AreasRepositoryTest`、`ShopsRepositoryTest` を新規追加
- `DeleteShopAndImageUseCaseTest`、`AddReportViewModelTest` を新規追加
- `AddAreaViewModelTest`、`EditAreaViewModelTest`、`EditShopViewModelTest` を新規追加

### 影響範囲

- 新規ファイル: `LoadFullReportsByAreaUseCase`、`LoadFullReportsByShopUseCase`、`LoadAreaImageUseCase`、`AddReportButton`、`EditShopButton`、`ScheduleButton`、各テストファイル
- 変更ファイル: `DeleteAreaUseCase`、`DeleteShopAndImageUseCase`、`HistoryScreen`、`EditAreaViewModel`、`AddShopScreen`、`ShopScreen` など
- 破壊的変更: なし