### PR TITLE
HistoryScreenに年フィルタードロップダウンを追加

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -139,6 +139,7 @@
     <!-- History Screen -->
     <string name="history_no_data">食レポがありません。\n「ノート」の店舗画面に遷移し、食レポを登録してください。</string>
     <string name="history_year">年</string>
+    <string name="history_year_all">全て</string>
     <string name="history_search_hint">店舗名を入力して下さい</string>
 
     <!-- Settings Screen -->

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -44,6 +44,8 @@ import dev.seabat.ramennote.domain.usecase.LoadImageUseCase
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCase
 import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCase
+import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadScheduledShopsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadScheduledShopsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCase
@@ -101,6 +103,7 @@ val useCaseModule =
         single<LoadFullReportsUseCaseContract> { LoadFullReportsUseCase(get(), get(), get()) }
         single<LoadFullReportsByShopUseCaseContract> { LoadFullReportsByShopUseCase(get(), get(), get()) }
         single<LoadFullReportsByAreaUseCaseContract> { LoadFullReportsByAreaUseCase(get(), get(), get()) }
+        single<LoadReportsByYearUseCaseContract> { LoadReportsByYearUseCase(get(), get(), get()) }
         single<LoadThreeMonthsFullReportsUseCaseContract> {
             LoadThreeMonthsFullReportsUseCase(
                 get(),

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
@@ -1,0 +1,41 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.FullReport
+import dev.seabat.ramennote.domain.model.RunStatus
+
+class LoadReportsByYearUseCase(
+    private val reportsRepository: ReportsRepositoryContract,
+    private val shopsRepository: ShopsRepositoryContract,
+    private val localImageRepository: LocalImageRepositoryContract
+) : LoadReportsByYearUseCaseContract {
+    override suspend operator fun invoke(year: Int): List<FullReport> {
+        val reports = reportsRepository.load().filter { it.date?.year == year }
+
+        return reports.map { report ->
+            val shop = shopsRepository.getShopById(report.shopId)
+            val imageBytes = localImageRepository.load(report.photoName)
+            FullReport(
+                id = report.id,
+                shopId = report.shopId,
+                shopName = shop?.name ?: "不明な店舗",
+                menuName = report.menuName,
+                photoName = report.photoName,
+                imageBytes =
+                    when (imageBytes) {
+                        is RunStatus.Success ->
+                            imageBytes.data
+                        is RunStatus.Error ->
+                            null
+                        else -> error("unexpected state")
+                    },
+                impression = report.impression,
+                date = report.date!!,
+                star = report.star,
+                areaId = report.areaId
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCaseContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.FullReport
+
+interface LoadReportsByYearUseCaseContract {
+    suspend operator fun invoke(year: Int): List<FullReport>
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
@@ -26,7 +26,7 @@ val viewModelModule =
         viewModel { EditAreaSortViewModel(get(), get()) }
         viewModel { EditReportViewModel(get(), get(), get(), get()) }
         viewModel { EditShopViewModel(get(), get(), get(), get()) }
-        viewModel { HistoryViewModel(get(), get(), get(), get(), get()) }
+        viewModel { HistoryViewModel(get(), get(), get(), get(), get(), get()) }
         viewModel { HomeViewModel(get(), get(), get(), get(), get(), get()) }
         viewModel { NoteViewModel(get(), get(), get()) }
         viewModel { AddReportViewModel(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
@@ -87,7 +87,7 @@ fun ShopDropdownField(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DropdownAnchorField(
+internal fun DropdownAnchorField(
     text: String,
     expanded: Boolean,
     onToggle: () -> Unit,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -13,8 +13,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,8 +36,8 @@ import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.banner.HintBanner
-import dev.seabat.ramennote.ui.components.button.ActionButton
 import dev.seabat.ramennote.ui.gallery.SharedImage
+import dev.seabat.ramennote.ui.screens.componens.DropdownAnchorField
 import dev.seabat.ramennote.ui.screens.componens.ReportCard
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
 import dev.seabat.ramennote.ui.screens.note.shop.SearchInputField
@@ -41,14 +45,13 @@ import dev.seabat.ramennote.ui.share.createRememberedXShareLauncher
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.composeapp.generated.resources.Res
-import ramennote.composeapp.generated.resources.filter_list_24px
 import ramennote.composeapp.generated.resources.history_no_data
 import ramennote.composeapp.generated.resources.history_search_hint
 import ramennote.composeapp.generated.resources.history_year
+import ramennote.composeapp.generated.resources.history_year_all
 import ramennote.composeapp.generated.resources.note_hit_count
 import ramennote.composeapp.generated.resources.note_notification
 import ramennote.composeapp.generated.resources.screen_history_title
@@ -69,6 +72,8 @@ fun HistoryScreen(
     val areaNameState by viewModel.areaName.collectAsState()
     val reportsState by viewModel.reports.collectAsState()
     val shops by viewModel.shops.collectAsState()
+    val yearState by viewModel.year.collectAsState()
+    val yearsState by viewModel.selectableYears.collectAsState()
 
     val listState = rememberLazyListState()
     var selectedImageBytes by remember { mutableStateOf<ByteArray?>(null) }
@@ -101,6 +106,8 @@ fun HistoryScreen(
                         "${stringResource(Res.string.screen_history_title)}($areaNameState)"
                     shopNameState.isNotEmpty() ->
                         "${stringResource(Res.string.screen_history_title)}($shopNameState)"
+                    yearState.isNotEmpty() ->
+                        "${stringResource(Res.string.screen_history_title)}($yearState)"
                     else -> stringResource(Res.string.screen_history_title)
                 }
         )
@@ -112,6 +119,8 @@ fun HistoryScreen(
                     listState = listState,
                     initialSearchText = initialSearchText,
                     shops = shops,
+                    years = yearsState,
+                    selectedYear = yearState,
                     goToEditReport = goToEditReport,
                     onDisplayImage = { imageBytes -> selectedImageBytes = imageBytes },
                     onFilter = { shop ->
@@ -130,7 +139,9 @@ fun HistoryScreen(
                     onSearchShop = { text ->
                         viewModel.searchShops(text)
                     },
-                    onCancelShopFilter = { viewModel.loadReports() }
+                    onCancelShopFilter = { viewModel.loadReports() },
+                    onYearSelect = { year -> viewModel.loadReportsByYear(year) },
+                    onClearYearFilter = { viewModel.loadReports() }
                 )
             }
 
@@ -185,7 +196,10 @@ fun HistoryScreen(
 @Composable
 private fun Menu(
     searchText: String,
-    onFilterClick: () -> Unit = {},
+    years: List<Int>,
+    selectedYear: String,
+    onYearSelect: (Int) -> Unit,
+    onClearYearFilter: () -> Unit,
     onSearchTextChange: (String) -> Unit
 ) {
     Row(
@@ -193,31 +207,74 @@ private fun Menu(
             Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 0.dp, vertical = 4.dp),
-//        horizontalArrangement = Arrangement.spacedBy(8.dp)
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        YearButton(onClick = onFilterClick)
-        Spacer(modifier = Modifier.width(16.dp))
-        SearchInputField(
-            placeholder = stringResource(Res.string.history_search_hint),
-            value = searchText,
-            onValueChange = onSearchTextChange
+        YearDropdownField(
+            years = years,
+            selectedYear = selectedYear,
+            onYearSelect = onYearSelect,
+            onClearYearFilter = onClearYearFilter,
+            modifier = Modifier.width(100.dp)
         )
+        Spacer(modifier = Modifier.width(16.dp))
+        Box(modifier = Modifier.weight(1f)) {
+            SearchInputField(
+                placeholder = stringResource(Res.string.history_search_hint),
+                value = searchText,
+                onValueChange = onSearchTextChange
+            )
+        }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun YearButton(
-    onClick: () -> Unit,
+private fun YearDropdownField(
+    years: List<Int>,
+    selectedYear: String,
+    onYearSelect: (Int) -> Unit,
+    onClearYearFilter: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    ActionButton(
-        icon = vectorResource(Res.drawable.filter_list_24px),
-        text = stringResource(Res.string.history_year),
-        onClick = onClick,
+    var expanded by remember { mutableStateOf(false) }
+    val allLabel = stringResource(Res.string.history_year_all)
+    val yearHint = stringResource(Res.string.history_year)
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
         modifier = modifier
-    )
+    ) {
+        DropdownAnchorField(
+            text = if (selectedYear.isNotEmpty()) selectedYear else yearHint,
+            expanded = expanded,
+            onToggle = { expanded = !expanded },
+            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            // 「全て」選択肢
+            DropdownMenuItem(
+                text = { Text(allLabel) },
+                onClick = {
+                    onClearYearFilter()
+                    expanded = false
+                }
+            )
+            years.forEach { year ->
+                DropdownMenuItem(
+                    text = { Text(year.toString()) },
+                    onClick = {
+                        onYearSelect(year)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
 }
 
 /**
@@ -244,12 +301,16 @@ private fun ReportList(
     listState: LazyListState,
     initialSearchText: String,
     shops: List<Shop>,
+    years: List<Int>,
+    selectedYear: String,
     goToEditReport: (Int) -> Unit,
     onDisplayImage: (ByteArray?) -> Unit,
     onFilter: (Shop) -> Unit = {},
     onShare: (String, ByteArray?) -> Unit,
     onSearchShop: (String) -> Unit = {},
-    onCancelShopFilter: () -> Unit = {}
+    onCancelShopFilter: () -> Unit = {},
+    onYearSelect: (Int) -> Unit = {},
+    onClearYearFilter: () -> Unit = {}
 ) {
     var isSearchResultVisible by remember { mutableStateOf(initialSearchText.isNotEmpty()) }
     var searchText by remember { mutableStateOf(initialSearchText) }
@@ -272,10 +333,22 @@ private fun ReportList(
         item {
             Menu(
                 searchText = searchText,
-                onFilterClick = {},
+                years = years,
+                selectedYear = selectedYear,
+                onYearSelect = { year ->
+                    // 年フィルター選択時は検索テキストをクリア
+                    searchText = ""
+                    isSearchResultVisible = false
+                    onYearSelect(year)
+                },
+                onClearYearFilter = onClearYearFilter,
                 onSearchTextChange = { text ->
                     searchText = text
                     if (text.isNotEmpty()) {
+                        // 店舗検索時は年フィルターを解除
+                        if (selectedYear.isNotEmpty()) {
+                            onClearYearFilter()
+                        }
                         isSearchResultVisible = true
                         onSearchShop(text)
                     } else {
@@ -359,6 +432,10 @@ private fun MenuPreview() {
     RamenNoteTheme {
         Menu(
             searchText = "",
+            years = listOf(2025, 2024),
+            selectedYear = "",
+            onYearSelect = {},
+            onClearYearFilter = {},
             onSearchTextChange = {}
         )
     }
@@ -370,6 +447,10 @@ private fun MenuWithSearchTextPreview() {
     RamenNoteTheme {
         Menu(
             searchText = "麺屋",
+            years = listOf(2025, 2024),
+            selectedYear = "",
+            onYearSelect = {},
+            onClearYearFilter = {},
             onSearchTextChange = {}
         )
     }
@@ -385,11 +466,22 @@ fun HistoryScreenPreview() {
 
 @Preview
 @Composable
-fun HistoryScreenForSearchPreview() {
+fun HistoryScreenForSearchWithNoHitPreview() {
     RamenNoteTheme {
         HistoryScreen(
             initialSearchText = "一風堂",
             viewModel = MockHistoryViewModel()
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HistoryScreenForSearchWithHitsPreview() {
+    RamenNoteTheme {
+        HistoryScreen(
+            initialSearchText = "一風堂",
+            viewModel = MockHistoryViewModelWithSearchHits()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
@@ -8,6 +8,7 @@ import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsByAreaUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsByShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadFullReportsUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SearchShopsByNameUseCaseContract
 import dev.seabat.ramennote.ui.gallery.SharedImage
 import dev.seabat.ramennote.ui.share.XShareLauncher
@@ -21,7 +22,8 @@ class HistoryViewModel(
     private val loadReportsByShopUseCase: LoadFullReportsByShopUseCaseContract,
     private val loadReportsByAreaUseCase: LoadFullReportsByAreaUseCaseContract,
     private val loadAreasUseCase: LoadAreasUseCaseContract,
-    private val searchShopsByNameUseCase: SearchShopsByNameUseCaseContract
+    private val searchShopsByNameUseCase: SearchShopsByNameUseCaseContract,
+    private val loadReportsByYearUseCase: LoadReportsByYearUseCaseContract
 ) : ViewModel(),
     HistoryViewModelContract {
     private val _reports = MutableStateFlow<List<FullReport>>(emptyList())
@@ -36,17 +38,32 @@ class HistoryViewModel(
     private val _areaName = MutableStateFlow<String>("")
     override val areaName: StateFlow<String> = _areaName.asStateFlow()
 
+    private val _year = MutableStateFlow<String>("")
+    override val year: StateFlow<String> = _year.asStateFlow()
+
+    private val _selectableYears = MutableStateFlow<List<Int>>(emptyList())
+    override val selectableYears: StateFlow<List<Int>> = _selectableYears.asStateFlow()
+
     override fun loadReports() {
         viewModelScope.launch {
             _shopName.value = ""
             _areaName.value = ""
+            _year.value = ""
             _reports.value = loadReportsUseCase.invoke()
+            _selectableYears.value =
+                _reports.value
+                    .map { it.date.year }
+                    .distinct()
+                    .sortedDescending()
         }
     }
 
     override fun loadReportsByShop(shopId: Int) {
         viewModelScope.launch {
+            // 店舗でフィルタリングする場合は他のフィルタリングを解除
             _areaName.value = ""
+            _year.value = ""
+
             _reports.value = loadReportsByShopUseCase.invoke(shopId)
             // 店舗名は FullReport.shopName から取得
             _shopName.value = _reports.value.firstOrNull()?.shopName ?: ""
@@ -55,10 +72,24 @@ class HistoryViewModel(
 
     override fun loadReportsByArea(areaId: Int) {
         viewModelScope.launch {
+            // エリアでフィルタリングする場合は他のフィルタリングを解除
             _shopName.value = ""
+            _year.value = ""
+
             _reports.value = loadReportsByAreaUseCase.invoke(areaId)
             // エリア名を areas テーブルから取得
             _areaName.value = loadAreasUseCase().find { it.areaId == areaId }?.name ?: ""
+        }
+    }
+
+    override fun loadReportsByYear(year: Int) {
+        viewModelScope.launch {
+            // 年でフィルタリングする場合は他のフィルタリングを解除
+            _shopName.value = ""
+            _areaName.value = ""
+
+            _reports.value = loadReportsByYearUseCase.invoke(year)
+            _year.value = year.toString()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModelContract.kt
@@ -11,12 +11,16 @@ interface HistoryViewModelContract {
     val shopName: StateFlow<String>
     val areaName: StateFlow<String>
     val shops: StateFlow<List<Shop>>
+    val year: StateFlow<String>
+    val selectableYears: StateFlow<List<Int>>
 
     fun loadReports()
 
     fun loadReportsByShop(shopId: Int)
 
     fun loadReportsByArea(areaId: Int)
+
+    fun loadReportsByYear(year: Int)
 
     fun shareToX(postText: String, image: SharedImage?, xShareLauncher: XShareLauncher)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
@@ -22,6 +22,12 @@ class MockHistoryViewModel : HistoryViewModelContract {
     private val _shops = MutableStateFlow<List<Shop>>(emptyList())
     override val shops: StateFlow<List<Shop>> = _shops.asStateFlow()
 
+    private val _year = MutableStateFlow<String>("")
+    override val year: StateFlow<String> = _year.asStateFlow()
+
+    private val _years = MutableStateFlow<List<Int>>(emptyList())
+    override val selectableYears: StateFlow<List<Int>> = _years.asStateFlow()
+
     init {
         // プレビューで LaunchedEffect が動かない場合でも表示されるよう初期化
         loadReports()
@@ -97,6 +103,11 @@ class MockHistoryViewModel : HistoryViewModelContract {
                     star = 3
                 )
             )
+        _years.value =
+            _reports.value
+                .map { it.date.year }
+                .distinct()
+                .sortedDescending()
     }
 
     override fun loadReportsByShop(shopId: Int) {
@@ -107,6 +118,10 @@ class MockHistoryViewModel : HistoryViewModelContract {
         // Preview用なので何もしない
     }
 
+    override fun loadReportsByYear(year: Int) {
+        // Preview用なので何もしない
+    }
+
     override fun shareToX(
         postText: String,
         image: SharedImage?,
@@ -114,6 +129,23 @@ class MockHistoryViewModel : HistoryViewModelContract {
     ) {
         // Preview用なので何もしない
     }
+
+    override fun searchShops(query: String) {
+        // Preview用なので何もしない
+    }
+}
+
+/** 店舗検索でヒットがある状態のプレビュー用モック */
+class MockHistoryViewModelWithSearchHits : HistoryViewModelContract by MockHistoryViewModel() {
+    private val _shops =
+        MutableStateFlow(
+            listOf(
+                Shop(id = 1, name = "一風堂 渋谷店", areaId = 1),
+                Shop(id = 2, name = "一風堂 新宿店", areaId = 1),
+                Shop(id = 3, name = "一風堂 池袋店", areaId = 2)
+            )
+        )
+    override val shops: StateFlow<List<Shop>> = _shops.asStateFlow()
 
     override fun searchShops(query: String) {
         // Preview用なので何もしない


### PR DESCRIPTION
## 概要

HistoryScreen に年単位でレポートをフィルタリングできるドロップダウンメニューを追加した。従来の年ボタンを `ExposedDropdownMenuBox` ベースの `YearDropdownField` に置き換え、店舗検索との相互排他ロジックを実装している。

## 変更内容

- **`LoadReportsByYearUseCase`** を新規作成し、年単位でのレポートフィルタリングを実現
- **`HistoryViewModel`** に `year` / `selectableYears` StateFlow と `loadReportsByYear()` を追加
- **`HistoryScreen`** の年ボタンを `YearDropdownField`（`ExposedDropdownMenuBox` ベース）に置き換え
- 年フィルターと店舗検索の相互排他ロジックを実装（どちらか一方のみ有効）
- AppBar タイトルに選択中の年を反映
- **`MockHistoryViewModelWithSearchHits`** を追加し、検索ヒット時のプレビューを拡充

## テスト

- HistoryScreen を起動し、年ドロップダウンから年を選択してレポートが絞り込まれることを確認
- 年フィルター適用中に店舗検索を行うと年フィルターがリセットされることを確認
- 店舗検索中に年を選択すると検索がリセットされることを確認
- AppBar タイトルに選択年が正しく表示されることを確認
- Compose プレビューで `MockHistoryViewModelWithSearchHits` が正しく表示されることを確認