### PR TITLE
HistoryScreen拡張とUseCase層の品質向上

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -91,7 +91,7 @@ val useCaseModule =
         single<DeleteShopAndImageUseCaseContract> { DeleteShopAndImageUseCase(get(), get(), get(), get()) }
         single<FetchAiShopUseCaseContract> { FetchAiShopInfoUseCase(get(), get()) }
         single<FetchPlaceHolderImageUseCaseContract> { FetchPlaceHolderImageUseCase(get(), get()) }
-        single<FetchAndSaveUnsplashImageUseCaseContract> { FetchAndSaveUnsplashImageUseCase(get(), get()) }
+        single<FetchAndSaveUnsplashImageUseCaseContract> { FetchAndSaveUnsplashImageUseCase(get(), get(), get()) }
         single<InquiryAppVersionUseCaseContract> { InquiryAppVersionUseCase(get()) }
         single<LoadAreasUseCaseContract> { LoadAreasUseCase(get()) }
         single<LoadAreaImageUseCaseContract> { LoadAreaImageUseCase(get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -1,5 +1,7 @@
 package dev.seabat.ramennote.domain.di
 
+import dev.seabat.ramennote.domain.usecase.AddAreaUseCase
+import dev.seabat.ramennote.domain.usecase.AddAreaUseCaseContract
 import dev.seabat.ramennote.domain.usecase.AddReportUseCase
 import dev.seabat.ramennote.domain.usecase.AddReportUseCaseContract
 import dev.seabat.ramennote.domain.usecase.AddShopUseCase
@@ -81,6 +83,7 @@ import org.koin.dsl.module
 val useCaseModule =
     module {
         single<UpdateScheduleInShopUseCaseContract> { UpdateScheduleInShopUseCase(get()) }
+        single<AddAreaUseCaseContract> { AddAreaUseCase(get()) }
         single<AddShopUseCaseContract> { AddShopUseCase(get(), get(), get()) }
         single<CreateNoImageByteArrayUseCaseContract> { CreateNoImageByteArrayUseCase(get()) }
         single<CreateNoImageIfNeededUseCaseContract> { CreateNoImageIfNeededUseCase(get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddAreaUseCase.kt
@@ -1,0 +1,29 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.util.createTodayLocalDate
+
+class AddAreaUseCase(
+    private val areasRepository: AreasRepositoryContract
+) : AddAreaUseCaseContract {
+    override suspend operator fun invoke(areaName: String): RunStatus<String> {
+        val trimmedName = areaName.trim()
+
+        // 同じ名前のエリアがすでに登録されていないかチェック
+        if (areasRepository.load(trimmedName) != null) {
+            return RunStatus.Error("すでに同じエリア名が登録されています")
+        }
+
+        areasRepository.add(
+            Area(
+                name = trimmedName,
+                updatedDate = createTodayLocalDate(),
+                count = 0,
+                sort = 0
+            )
+        )
+        return RunStatus.Success("")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/AddAreaUseCaseContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.RunStatus
+
+interface AddAreaUseCaseContract {
+    suspend operator fun invoke(areaName: String): RunStatus<String>
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchAndSaveUnsplashImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchAndSaveUnsplashImageUseCase.kt
@@ -1,20 +1,26 @@
 package dev.seabat.ramennote.domain.usecase
 
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.data.repository.UnsplashImageRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.util.createTodayLocalDate
 
 /**
  * Unsplash から画像を取得し、ローカルストレージに保存する
  *
+ * 画像取得に成功した場合は、areas テーブルの該当レコードの updatedDate を本日の日付で更新する。
  *
  * @property unsplashImageRepository
  * @property localAreaImageRepository
+ * @property areasRepository
  */
 class FetchAndSaveUnsplashImageUseCase(
     private val unsplashImageRepository: UnsplashImageRepositoryContract,
-    private val localAreaImageRepository: LocalImageRepositoryContract
+    private val localAreaImageRepository: LocalImageRepositoryContract,
+    private val areasRepository: AreasRepositoryContract
 ) : FetchAndSaveUnsplashImageUseCaseContract {
+
     override suspend operator fun invoke(query: String): RunStatus<ByteArray> {
         // Fetch image from remote repository
         return when (val fetchResult = unsplashImageRepository.fetch(query)) {
@@ -26,9 +32,14 @@ class FetchAndSaveUnsplashImageUseCase(
                 // Save to local storage with query as filename
                 localAreaImageRepository.save(imageBytes, query)
 
+                // areas テーブルの updatedDate を本日の日付で更新する
+                areasRepository.load(query)?.let { area ->
+                    areasRepository.edit(area.copy(updatedDate = createTodayLocalDate()))
+                }
+
                 // Load from local storage with query as filename
-                when (val localImageBytes = localAreaImageRepository.load(query)) {
-                    is RunStatus.Success -> localImageBytes
+                when (val runStatus = localAreaImageRepository.load(query)) {
+                    is RunStatus.Success -> runStatus
                     is RunStatus.Error -> RunStatus.Error("Failed to load image from local storage")
                     else -> error("unexpected state")
                 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
@@ -5,37 +5,42 @@ import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class LoadFullReportsByAreaUseCase(
     private val reportsRepository: ReportsRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract,
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadFullReportsByAreaUseCaseContract {
-    override suspend operator fun invoke(areaId: Int): List<FullReport> {
-        val reports = reportsRepository.loadByAreaId(areaId)
+    override operator fun invoke(areaId: Int): Flow<FullReport> =
+        flow {
+            val reports = reportsRepository.loadByAreaId(areaId)
 
-        return reports.map { report ->
-            val shop = shopsRepository.getShopById(report.shopId)
-            val imageBytes = localImageRepository.load(report.photoName)
-            FullReport(
-                id = report.id,
-                shopId = report.shopId,
-                shopName = shop?.name ?: "不明な店舗",
-                menuName = report.menuName,
-                photoName = report.photoName,
-                imageBytes =
-                    when (imageBytes) {
-                        is RunStatus.Success ->
-                            imageBytes.data
-                        is RunStatus.Error ->
-                            null
-                        else -> error("unexpected state")
-                    },
-                impression = report.impression,
-                date = report.date!!,
-                star = report.star,
-                areaId = report.areaId
-            )
+            reports.forEach { report ->
+                val shop = shopsRepository.getShopById(report.shopId)
+                val imageBytes = localImageRepository.load(report.photoName)
+                emit(
+                    FullReport(
+                        id = report.id,
+                        shopId = report.shopId,
+                        shopName = shop?.name ?: "不明な店舗",
+                        menuName = report.menuName,
+                        photoName = report.photoName,
+                        imageBytes =
+                            when (imageBytes) {
+                                is RunStatus.Success ->
+                                    imageBytes.data
+                                is RunStatus.Error ->
+                                    null
+                                else -> error("unexpected state")
+                            },
+                        impression = report.impression,
+                        date = report.date!!,
+                        star = report.star,
+                        areaId = report.areaId
+                    )
+                )
+            }
         }
-    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCaseContract.kt
@@ -1,10 +1,11 @@
 package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.domain.model.FullReport
+import kotlinx.coroutines.flow.Flow
 
 /**
  * 画像データを含めた食レポデータを areaId でフィルタリングして読み込む
  */
 interface LoadFullReportsByAreaUseCaseContract {
-    suspend operator fun invoke(areaId: Int): List<FullReport>
+    operator fun invoke(areaId: Int): Flow<FullReport>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
@@ -5,37 +5,42 @@ import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class LoadFullReportsByShopUseCase(
     private val reportsRepository: ReportsRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract,
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadFullReportsByShopUseCaseContract {
-    override suspend operator fun invoke(shopId: Int): List<FullReport> {
-        val reports = reportsRepository.load().filter { it.shopId == shopId }
+    override operator fun invoke(shopId: Int): Flow<FullReport> =
+        flow {
+            val reports = reportsRepository.load().filter { it.shopId == shopId }
 
-        return reports.map { report ->
-            val shop = shopsRepository.getShopById(report.shopId)
-            val imageBytes = localImageRepository.load(report.photoName)
-            FullReport(
-                id = report.id,
-                shopId = report.shopId,
-                shopName = shop?.name ?: "不明な店舗",
-                menuName = report.menuName,
-                photoName = report.photoName,
-                imageBytes =
-                    when (imageBytes) {
-                        is RunStatus.Success ->
-                            imageBytes.data
-                        is RunStatus.Error ->
-                            null
-                        else -> error("unexpected state")
-                    },
-                impression = report.impression,
-                date = report.date!!,
-                star = report.star,
-                areaId = report.areaId
-            )
+            reports.forEach { report ->
+                val shop = shopsRepository.getShopById(report.shopId)
+                val imageBytes = localImageRepository.load(report.photoName)
+                emit(
+                    FullReport(
+                        id = report.id,
+                        shopId = report.shopId,
+                        shopName = shop?.name ?: "不明な店舗",
+                        menuName = report.menuName,
+                        photoName = report.photoName,
+                        imageBytes =
+                            when (imageBytes) {
+                                is RunStatus.Success ->
+                                    imageBytes.data
+                                is RunStatus.Error ->
+                                    null
+                                else -> error("unexpected state")
+                            },
+                        impression = report.impression,
+                        date = report.date!!,
+                        star = report.star,
+                        areaId = report.areaId
+                    )
+                )
+            }
         }
-    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCaseContract.kt
@@ -1,10 +1,11 @@
 package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.domain.model.FullReport
+import kotlinx.coroutines.flow.Flow
 
 /**
  * 画像データを含めた食レポデータを shopId でフィルタリングして読み込む
  */
 interface LoadFullReportsByShopUseCaseContract {
-    suspend operator fun invoke(shopId: Int): List<FullReport>
+    operator fun invoke(shopId: Int): Flow<FullReport>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
@@ -5,37 +5,42 @@ import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class LoadFullReportsUseCase(
     private val reportsRepository: ReportsRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract,
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadFullReportsUseCaseContract {
-    override suspend operator fun invoke(): List<FullReport> {
-        val reports = reportsRepository.load()
+    override operator fun invoke(): Flow<FullReport> =
+        flow {
+            val reports = reportsRepository.load()
 
-        return reports.map { report ->
-            val shop = shopsRepository.getShopById(report.shopId)
-            val imageBytes = localImageRepository.load(report.photoName)
-            FullReport(
-                id = report.id,
-                shopId = report.shopId,
-                shopName = shop?.name ?: "不明な店舗",
-                menuName = report.menuName,
-                photoName = report.photoName,
-                imageBytes =
-                    when (imageBytes) {
-                        is RunStatus.Success ->
-                            imageBytes.data
-                        is RunStatus.Error ->
-                            null
-                        else -> error("unexpected state")
-                    },
-                impression = report.impression,
-                date = report.date!!,
-                star = report.star,
-                areaId = report.areaId
-            )
+            reports.forEach { report ->
+                val shop = shopsRepository.getShopById(report.shopId)
+                val imageBytes = localImageRepository.load(report.photoName)
+                emit(
+                    FullReport(
+                        id = report.id,
+                        shopId = report.shopId,
+                        shopName = shop?.name ?: "不明な店舗",
+                        menuName = report.menuName,
+                        photoName = report.photoName,
+                        imageBytes =
+                            when (imageBytes) {
+                                is RunStatus.Success ->
+                                    imageBytes.data
+                                is RunStatus.Error ->
+                                    null
+                                else -> error("unexpected state")
+                            },
+                        impression = report.impression,
+                        date = report.date!!,
+                        star = report.star,
+                        areaId = report.areaId
+                    )
+                )
+            }
         }
-    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCaseContract.kt
@@ -1,10 +1,11 @@
 package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.domain.model.FullReport
+import kotlinx.coroutines.flow.Flow
 
 /**
  * 画像データを含めた全食レポデータを読み込む
  */
 interface LoadFullReportsUseCaseContract {
-    suspend operator fun invoke(): List<FullReport>
+    operator fun invoke(): Flow<FullReport>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
@@ -5,37 +5,42 @@ import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class LoadReportsByYearUseCase(
     private val reportsRepository: ReportsRepositoryContract,
     private val shopsRepository: ShopsRepositoryContract,
     private val localImageRepository: LocalImageRepositoryContract
 ) : LoadReportsByYearUseCaseContract {
-    override suspend operator fun invoke(year: Int): List<FullReport> {
-        val reports = reportsRepository.load().filter { it.date?.year == year }
+    override operator fun invoke(year: Int): Flow<FullReport> =
+        flow {
+            val reports = reportsRepository.load().filter { it.date?.year == year }
 
-        return reports.map { report ->
-            val shop = shopsRepository.getShopById(report.shopId)
-            val imageBytes = localImageRepository.load(report.photoName)
-            FullReport(
-                id = report.id,
-                shopId = report.shopId,
-                shopName = shop?.name ?: "不明な店舗",
-                menuName = report.menuName,
-                photoName = report.photoName,
-                imageBytes =
-                    when (imageBytes) {
-                        is RunStatus.Success ->
-                            imageBytes.data
-                        is RunStatus.Error ->
-                            null
-                        else -> error("unexpected state")
-                    },
-                impression = report.impression,
-                date = report.date!!,
-                star = report.star,
-                areaId = report.areaId
-            )
+            reports.forEach { report ->
+                val shop = shopsRepository.getShopById(report.shopId)
+                val imageBytes = localImageRepository.load(report.photoName)
+                emit(
+                    FullReport(
+                        id = report.id,
+                        shopId = report.shopId,
+                        shopName = shop?.name ?: "不明な店舗",
+                        menuName = report.menuName,
+                        photoName = report.photoName,
+                        imageBytes =
+                            when (imageBytes) {
+                                is RunStatus.Success ->
+                                    imageBytes.data
+                                is RunStatus.Error ->
+                                    null
+                                else -> error("unexpected state")
+                            },
+                        impression = report.impression,
+                        date = report.date!!,
+                        star = report.star,
+                        areaId = report.areaId
+                    )
+                )
+            }
         }
-    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCaseContract.kt
@@ -1,7 +1,8 @@
 package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.domain.model.FullReport
+import kotlinx.coroutines.flow.Flow
 
 interface LoadReportsByYearUseCaseContract {
-    suspend operator fun invoke(year: Int): List<FullReport>
+    operator fun invoke(year: Int): Flow<FullReport>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
@@ -17,19 +17,18 @@ class UpdateAreaImageUseCase(
     private val localAreaImageRepository: LocalImageRepositoryContract,
     private val fetchAndSaveUnsplashImageUseCase: FetchAndSaveUnsplashImageUseCaseContract
 ) : UpdateAreaImageUseCaseContract {
-    override suspend operator fun invoke(areaId: Int): RunStatus<ByteArray> {
-        val areaData =
-            areasRepository.loadByAreaId(areaId)
-                ?: return RunStatus.Error("エリアが見つかりません")
-        val areaName = areaData.name
+    override suspend operator fun invoke(areaName: String): RunStatus<ByteArray> {
 
         // まずローカルから画像を読み込む。画像がない場合は必ず Unsplash から取得
-        when (val runStatus = localAreaImageRepository.load(areaName)){
+        when (val runStatus = localAreaImageRepository.load(areaName)) {
             is RunStatus.Error if (runStatus.data == null) -> {
                 return fetchAndSaveUnsplashImageUseCase(areaName)
             }
             else -> {}
         }
+        val areaData =
+            areasRepository.load(areaName)
+                ?: return RunStatus.Error("エリアが登録されていません")
 
         val today = createTodayLocalDate()
         val needUpdate = areaData.updatedDate < today

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCase.kt
@@ -4,12 +4,18 @@ import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.util.createTodayLocalDate
-import kotlinx.datetime.minus
 
+/**
+ * エリア画像を更新する
+ *
+ * ローカルに画像が存在しない場合は Unsplash から取得して保存する。
+ * ローカルに画像が存在する場合は、最終更新日が今日より前であれば Unsplash から再取得して更新する。
+ * 最終更新日が今日の場合はエラーを返す。
+ */
 class UpdateAreaImageUseCase(
     private val areasRepository: AreasRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract,
-    private val fetchAndSaveUnsplashImageUseCaseContract: FetchAndSaveUnsplashImageUseCaseContract
+    private val fetchAndSaveUnsplashImageUseCase: FetchAndSaveUnsplashImageUseCaseContract
 ) : UpdateAreaImageUseCaseContract {
     override suspend operator fun invoke(areaId: Int): RunStatus<ByteArray> {
         val areaData =
@@ -17,13 +23,18 @@ class UpdateAreaImageUseCase(
                 ?: return RunStatus.Error("エリアが見つかりません")
         val areaName = areaData.name
 
-        // まずローカルから画像を読み込む。null なら必ず Unsplash から取得
-        localAreaImageRepository.load(areaName) ?: return fetchAndSaveUnsplashImageUseCaseContract(areaName)
+        // まずローカルから画像を読み込む。画像がない場合は必ず Unsplash から取得
+        when (val runStatus = localAreaImageRepository.load(areaName)){
+            is RunStatus.Error if (runStatus.data == null) -> {
+                return fetchAndSaveUnsplashImageUseCase(areaName)
+            }
+            else -> {}
+        }
 
         val today = createTodayLocalDate()
-        val needUpdate = areaData.updatedDate < today.minus(1, kotlinx.datetime.DateTimeUnit.DAY)
+        val needUpdate = areaData.updatedDate < today
         return if (needUpdate) {
-            fetchAndSaveUnsplashImageUseCaseContract(areaName)
+            fetchAndSaveUnsplashImageUseCase(areaName)
         } else {
             RunStatus.Error("本日は画像を変更できません。明日もう一度お試しください。")
         }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.RunStatus
 
 interface UpdateAreaImageUseCaseContract {
-    suspend operator fun invoke(areaId: Int): RunStatus<ByteArray>
+    suspend operator fun invoke(areaName: String): RunStatus<ByteArray>
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
@@ -12,6 +12,12 @@ class UpdateAreaUseCase(
         val oldName =
             areasRepository.loadByAreaId(areaId)?.name
                 ?: return RunStatus.Error("エリアが見つかりません")
+
+        // 同じ名前のエリアがすでに登録されていないかチェック（自分自身は除く）
+        if (oldName != newName && areasRepository.load(newName) != null) {
+            return RunStatus.Error("すでに同じエリア名が登録されています")
+        }
+
         val result = areasRepository.edit(oldName, newName)
         return if (result is RunStatus.Success) {
             try {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -78,6 +78,9 @@ fun HistoryScreen(
     val listState = rememberLazyListState()
     var selectedImageBytes by remember { mutableStateOf<ByteArray?>(null) }
     val xShareLauncher = createRememberedXShareLauncher()
+    // ReportList 再生成時に渡す初期値（店舗フィルター適用後も検索テキストを保持するため）
+    var listSearchText by remember { mutableStateOf(initialSearchText) }
+    var listIsSearchResultVisible by remember { mutableStateOf(initialSearchText.isNotEmpty()) }
 
     LaunchedEffect(Unit) {
         when {
@@ -117,13 +120,17 @@ fun HistoryScreen(
                 ReportList(
                     reports = reportsState,
                     listState = listState,
-                    initialSearchText = initialSearchText,
+                    searchText = listSearchText,
+                    isSearchResultVisible = listIsSearchResultVisible,
                     shops = shops,
                     years = yearsState,
                     selectedYear = yearState,
                     goToEditReport = goToEditReport,
                     onDisplayImage = { imageBytes -> selectedImageBytes = imageBytes },
                     onFilter = { shop ->
+                        // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
+                        listSearchText = shop.name
+                        listIsSearchResultVisible = false
                         viewModel.loadReportsByShop(shop.id)
                     },
                     onShare = { postText, imageBytes ->
@@ -136,11 +143,21 @@ fun HistoryScreen(
                             xShareLauncher = xShareLauncher
                         )
                     },
-                    onSearchShop = { text ->
-                        viewModel.searchShops(text)
+                    onSearchTextChange = { text ->
+                        listSearchText = text
+                        if (text.isNotEmpty()) {
+                            listIsSearchResultVisible = true
+                            viewModel.searchShops(text)
+                        } else {
+                            listIsSearchResultVisible = false
+                            viewModel.loadReports()
+                        }
                     },
-                    onCancelShopFilter = { viewModel.loadReports() },
-                    onYearSelect = { year -> viewModel.loadReportsByYear(year) },
+                    onYearSelect = { year ->
+                        listSearchText = ""
+                        listIsSearchResultVisible = false
+                        viewModel.loadReportsByYear(year)
+                    },
                     onClearYearFilter = { viewModel.loadReports() }
                 )
             }
@@ -188,41 +205,6 @@ fun HistoryScreen(
                 text = stringResource(Res.string.history_no_data),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.secondary
-            )
-        }
-    }
-}
-
-@Composable
-private fun Menu(
-    searchText: String,
-    years: List<Int>,
-    selectedYear: String,
-    onYearSelect: (Int) -> Unit,
-    onClearYearFilter: () -> Unit,
-    onSearchTextChange: (String) -> Unit
-) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 0.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        YearDropdownField(
-            years = years,
-            selectedYear = selectedYear,
-            onYearSelect = onYearSelect,
-            onClearYearFilter = onClearYearFilter,
-            modifier = Modifier.width(100.dp)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Box(modifier = Modifier.weight(1f)) {
-            SearchInputField(
-                placeholder = stringResource(Res.string.history_search_hint),
-                value = searchText,
-                onValueChange = onSearchTextChange
             )
         }
     }
@@ -286,20 +268,20 @@ private fun YearDropdownField(
  *
  * @param reports 表示する食レポのリスト
  * @param listState LazyColumnのスクロール状態
- * @param initialSearchText 初期表示時の検索テキスト
+ * @param searchText 初期表示時の検索テキスト
  * @param shops 検索結果として表示する店舗のリスト
  * @param goToEditReport 食レポ編集画面へ遷移するコールバック（reportIdを渡す）
  * @param onDisplayImage 画像を拡大表示させるコールバック（画像バイト列を渡す）
  * @param onFilter 食レポ一覧を店舗でフィルタリングするコールバック（Shop を渡す）
  * @param onShare シェアボタンタップ時のコールバック（テキストと画像バイト列を渡す）
- * @param onSearchShop 検索テキスト変更時に店舗検索を行うコールバック
- * @param onCancelShopFilter 食レポ一覧のフィルタリングを解除するコールバック
+ * @param onSearchTextChange 検索テキスト変更時のコールバック（空文字でフィルター解除）
  */
 @Composable
 private fun ReportList(
     reports: List<FullReport>,
     listState: LazyListState,
-    initialSearchText: String,
+    searchText: String,
+    isSearchResultVisible: Boolean,
     shops: List<Shop>,
     years: List<Int>,
     selectedYear: String,
@@ -307,13 +289,10 @@ private fun ReportList(
     onDisplayImage: (ByteArray?) -> Unit,
     onFilter: (Shop) -> Unit = {},
     onShare: (String, ByteArray?) -> Unit,
-    onSearchShop: (String) -> Unit = {},
-    onCancelShopFilter: () -> Unit = {},
+    onSearchTextChange: (String) -> Unit = {},
     onYearSelect: (Int) -> Unit = {},
     onClearYearFilter: () -> Unit = {}
 ) {
-    var isSearchResultVisible by remember { mutableStateOf(initialSearchText.isNotEmpty()) }
-    var searchText by remember { mutableStateOf(initialSearchText) }
     var isBannerVisible by remember { mutableStateOf(true) }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -335,27 +314,9 @@ private fun ReportList(
                 searchText = searchText,
                 years = years,
                 selectedYear = selectedYear,
-                onYearSelect = { year ->
-                    // 年フィルター選択時は検索テキストをクリア
-                    searchText = ""
-                    isSearchResultVisible = false
-                    onYearSelect(year)
-                },
+                onYearSelect = onYearSelect,
                 onClearYearFilter = onClearYearFilter,
-                onSearchTextChange = { text ->
-                    searchText = text
-                    if (text.isNotEmpty()) {
-                        // 店舗検索時は年フィルターを解除
-                        if (selectedYear.isNotEmpty()) {
-                            onClearYearFilter()
-                        }
-                        isSearchResultVisible = true
-                        onSearchShop(text)
-                    } else {
-                        isSearchResultVisible = false
-                        onCancelShopFilter()
-                    }
-                }
+                onSearchTextChange = onSearchTextChange
             )
         }
         if (isSearchResultVisible) {
@@ -381,7 +342,6 @@ private fun ReportList(
                     onShopClick = {
                         keyboardController?.hide()
                         onFilter(shop)
-                        isSearchResultVisible = false
                     },
                     onDelete = { /* 削除処理 */ }
                 )
@@ -414,6 +374,41 @@ private fun ReportList(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun Menu(
+    searchText: String,
+    years: List<Int>,
+    selectedYear: String,
+    onYearSelect: (Int) -> Unit,
+    onClearYearFilter: () -> Unit,
+    onSearchTextChange: (String) -> Unit
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 0.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        YearDropdownField(
+            years = years,
+            selectedYear = selectedYear,
+            onYearSelect = onYearSelect,
+            onClearYearFilter = onClearYearFilter,
+            modifier = Modifier.width(100.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Box(modifier = Modifier.weight(1f)) {
+            SearchInputField(
+                placeholder = stringResource(Res.string.history_search_hint),
+                value = searchText,
+                onValueChange = onSearchTextChange
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryViewModel.kt
@@ -15,6 +15,8 @@ import dev.seabat.ramennote.ui.share.XShareLauncher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class HistoryViewModel(
@@ -49,12 +51,17 @@ class HistoryViewModel(
             _shopName.value = ""
             _areaName.value = ""
             _year.value = ""
-            _reports.value = loadReportsUseCase.invoke()
-            _selectableYears.value =
-                _reports.value
-                    .map { it.date.year }
-                    .distinct()
-                    .sortedDescending()
+            _reports.value = emptyList()
+            loadReportsUseCase
+                .invoke()
+                .onEach { report ->
+                    _reports.value = _reports.value + report
+                    // 年フィルターリストを段階的に更新
+                    val newYear = report.date.year
+                    if (!_selectableYears.value.contains(newYear)) {
+                        _selectableYears.value = (_selectableYears.value + newYear).sortedDescending()
+                    }
+                }.collect()
         }
     }
 
@@ -63,10 +70,17 @@ class HistoryViewModel(
             // 店舗でフィルタリングする場合は他のフィルタリングを解除
             _areaName.value = ""
             _year.value = ""
-
-            _reports.value = loadReportsByShopUseCase.invoke(shopId)
-            // 店舗名は FullReport.shopName から取得
-            _shopName.value = _reports.value.firstOrNull()?.shopName ?: ""
+            _shopName.value = ""
+            _reports.value = emptyList()
+            loadReportsByShopUseCase
+                .invoke(shopId)
+                .onEach { report ->
+                    _reports.value = _reports.value + report
+                    // 店舗名は FullReport.shopName から取得（最初の1件で設定）
+                    if (_shopName.value.isEmpty()) {
+                        _shopName.value = report.shopName
+                    }
+                }.collect()
         }
     }
 
@@ -75,9 +89,14 @@ class HistoryViewModel(
             // エリアでフィルタリングする場合は他のフィルタリングを解除
             _shopName.value = ""
             _year.value = ""
-
-            _reports.value = loadReportsByAreaUseCase.invoke(areaId)
-            // エリア名を areas テーブルから取得
+            _areaName.value = ""
+            _reports.value = emptyList()
+            loadReportsByAreaUseCase
+                .invoke(areaId)
+                .onEach { report ->
+                    _reports.value = _reports.value + report
+                }.collect()
+            // エリア名を areas テーブルから取得（collect 完了後に設定）
             _areaName.value = loadAreasUseCase().find { it.areaId == areaId }?.name ?: ""
         }
     }
@@ -87,9 +106,13 @@ class HistoryViewModel(
             // 年でフィルタリングする場合は他のフィルタリングを解除
             _shopName.value = ""
             _areaName.value = ""
-
-            _reports.value = loadReportsByYearUseCase.invoke(year)
             _year.value = year.toString()
+            _reports.value = emptyList()
+            loadReportsByYearUseCase
+                .invoke(year)
+                .onEach { report ->
+                    _reports.value = _reports.value + report
+                }.collect()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockHistoryViewModel.kt
@@ -25,8 +25,8 @@ class MockHistoryViewModel : HistoryViewModelContract {
     private val _year = MutableStateFlow<String>("")
     override val year: StateFlow<String> = _year.asStateFlow()
 
-    private val _years = MutableStateFlow<List<Int>>(emptyList())
-    override val selectableYears: StateFlow<List<Int>> = _years.asStateFlow()
+    private val _selectableYears = MutableStateFlow<List<Int>>(emptyList())
+    override val selectableYears: StateFlow<List<Int>> = _selectableYears.asStateFlow()
 
     init {
         // プレビューで LaunchedEffect が動かない場合でも表示されるよう初期化
@@ -103,7 +103,7 @@ class MockHistoryViewModel : HistoryViewModelContract {
                     star = 3
                 )
             )
-        _years.value =
+        _selectableYears.value =
             _reports.value
                 .map { it.date.year }
                 .distinct()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaViewModel.kt
@@ -2,18 +2,16 @@ package dev.seabat.ramennote.ui.screens.note.addarea
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dev.seabat.ramennote.data.repository.AreasRepositoryContract
-import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.usecase.AddAreaUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCaseContract
-import dev.seabat.ramennote.domain.util.createTodayLocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class AddAreaViewModel(
-    private val areasRepository: AreasRepositoryContract,
+    private val addAreaUseCase: AddAreaUseCaseContract,
     private val fetchUnsplashImageUseCase: FetchAndSaveUnsplashImageUseCaseContract
 ) : ViewModel(),
     AddAreaViewModelContract {
@@ -22,18 +20,18 @@ class AddAreaViewModel(
     override val addState: StateFlow<RunStatus<ByteArray>> = _addState.asStateFlow()
 
     override fun addArea(area: String) {
-        val today = createTodayLocalDate()
         viewModelScope.launch {
             _addState.value = RunStatus.Loading()
-            areasRepository.add(
-                Area(
-                    name = area.trim(),
-                    updatedDate = today,
-                    count = 0,
-                    sort = 0
-                )
-            )
-            _addState.value = fetchUnsplashImageUseCase(area)
+            when (val result = addAreaUseCase(area)) {
+                is RunStatus.Success -> {
+                    // エリア登録成功後に Unsplash から画像を取得する
+                    _addState.value = fetchUnsplashImageUseCase(area)
+                }
+                is RunStatus.Error -> {
+                    _addState.value = RunStatus.Error(result.message ?: "エリアの登録に失敗しました")
+                }
+                else -> Unit
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -183,7 +183,11 @@ fun EditAreaScreen(
                 }
             )
         }
-        EditStatus(editStatus) { onCompleted() }
+        EditStatus(
+            editStatus,
+            onCompleted = { onCompleted() },
+            onClearCancel = { viewModel.resetEditState() }
+        )
         DeleteStatus(deleteStatus) { onCompleted() }
     }
 }
@@ -212,17 +216,18 @@ fun BottomButtons(
 
 @Composable
 fun EditStatus(
-    deleteStatus: RunStatus<String>,
-    onCompleted: () -> Unit
+    editStatus: RunStatus<String>,
+    onCompleted: () -> Unit,
+    onClearCancel: () -> Unit
 ) {
-    when (deleteStatus) {
+    when (editStatus) {
         is RunStatus.Success -> {
             onCompleted()
         }
         is RunStatus.Error -> {
             AppAlert(
-                message = "${deleteStatus.message}",
-                onConfirm = { onCompleted() }
+                message = "${editStatus.message}",
+                onConfirm = { onClearCancel() }
             )
         }
         is RunStatus.Loading -> {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -115,7 +115,7 @@ fun EditAreaScreen(
                     Spacer(Modifier.height(16.dp))
 
                     Button(
-                        onClick = { viewModel.fetchNewImage(areaId) },
+                        onClick = { viewModel.fetchNewImage(areaNameInput) },
                         colors =
                             ButtonDefaults.buttonColors(
                                 containerColor = MaterialTheme.colorScheme.tertiaryContainer,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -53,10 +53,10 @@ class EditAreaViewModel(
         }
     }
 
-    override fun fetchNewImage(areaId: Int) {
+    override fun fetchNewImage(areaName: String) {
         viewModelScope.launch {
             _imageState.value = RunStatus.Loading()
-            _imageState.value = updateAreaImageUseCase(areaId)
+            _imageState.value = updateAreaImageUseCase(areaName)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -78,4 +78,8 @@ class EditAreaViewModel(
     override fun resetImageState() {
         _imageState.value = RunStatus.Idle()
     }
+
+    override fun resetEditState() {
+        _editState.value = RunStatus.Idle()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
@@ -20,4 +20,5 @@ interface EditAreaViewModelContract {
     fun loadImage(areaId: Int)
 
     fun resetImageState()
+    fun resetEditState()
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModelContract.kt
@@ -13,7 +13,7 @@ interface EditAreaViewModelContract {
 
     fun deleteArea(areaId: Int)
 
-    fun fetchNewImage(areaId: Int)
+    fun fetchNewImage(areaName: String)
 
     fun loadAreaName(areaId: Int)
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
@@ -26,7 +26,7 @@ class MockEditAreaViewModel :
         // Preview用なので何もしない
     }
 
-    override fun fetchNewImage(areaId: Int) {
+    override fun fetchNewImage(areaName: String) {
         // Preview用なので何もしない
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/MockEditAreaViewModel.kt
@@ -41,4 +41,8 @@ class MockEditAreaViewModel :
     override fun resetImageState() {
         // Preview用なので何もしない
     }
+
+    override fun resetEditState() {
+        // Preview用なので何もしない
+    }
 }

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseTest.kt
@@ -1,0 +1,184 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.RunStatus
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class UpdateAreaImageUseCaseTest {
+
+    private val fakeAreasRepository = FakeAreasRepository()
+    private val fakeLocalImageRepository = FakeLocalImageRepository()
+    private val fakeFetchAndSaveUnsplashImageUseCase = FakeFetchAndSaveUnsplashImageUseCase()
+
+    private val useCase = UpdateAreaImageUseCase(
+        areasRepository = fakeAreasRepository,
+        localAreaImageRepository = fakeLocalImageRepository,
+        fetchAndSaveUnsplashImageUseCase = fakeFetchAndSaveUnsplashImageUseCase
+    )
+
+    // --- エリアが存在しない場合 ---
+
+    @Test
+    fun `invoke - エリアが存在しない場合はRunStatus_Errorを返す`() = runTest {
+        fakeAreasRepository.area = null
+
+        val result = useCase(999)
+
+        assertIs<RunStatus.Error<ByteArray>>(result)
+        assertEquals("エリアが見つかりません", result.message)
+    }
+
+    @Test
+    fun `invoke - エリアが存在しない場合はUnsplash取得が呼ばれない`() = runTest {
+        fakeAreasRepository.area = null
+
+        useCase(999)
+
+        assertEquals(null, fakeFetchAndSaveUnsplashImageUseCase.invokedQuery)
+    }
+
+    // --- ローカル画像が存在しない場合 ---
+
+    @Test
+    fun `invoke - ローカル画像がない場合はUnsplash取得が呼ばれる`() = runTest {
+        fakeAreasRepository.area = createTestArea(name = "渋谷", updatedDate = LocalDate(2000, 1, 1))
+        fakeLocalImageRepository.loadResult = RunStatus.Error("画像なし")
+        fakeFetchAndSaveUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf(1, 2, 3))
+
+        useCase(1)
+
+        assertEquals("渋谷", fakeFetchAndSaveUnsplashImageUseCase.invokedQuery)
+    }
+
+    @Test
+    fun `invoke - ローカル画像がない場合はUnsplash取得の結果をそのまま返す`() = runTest {
+        val imageBytes = byteArrayOf(1, 2, 3)
+        fakeAreasRepository.area = createTestArea(name = "渋谷", updatedDate = LocalDate(2000, 1, 1))
+        fakeLocalImageRepository.loadResult = RunStatus.Error("画像なし")
+        fakeFetchAndSaveUnsplashImageUseCase.result = RunStatus.Success(imageBytes)
+
+        val result = useCase(1)
+
+        assertIs<RunStatus.Success<ByteArray>>(result)
+        assertEquals(imageBytes, result.data)
+    }
+
+    // --- ローカル画像が存在する + updatedDate が過去の場合 ---
+
+    @Test
+    fun `invoke - ローカル画像があり更新日が過去の場合はUnsplash取得が呼ばれる`() = runTest {
+        fakeAreasRepository.area = createTestArea(name = "新宿", updatedDate = LocalDate(2000, 1, 1))
+        fakeLocalImageRepository.loadResult = RunStatus.Success(byteArrayOf(10, 20))
+        fakeFetchAndSaveUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf(30, 40))
+
+        useCase(1)
+
+        assertEquals("新宿", fakeFetchAndSaveUnsplashImageUseCase.invokedQuery)
+    }
+
+    @Test
+    fun `invoke - ローカル画像があり更新日が過去の場合はUnsplash取得の結果をそのまま返す`() = runTest {
+        val newImageBytes = byteArrayOf(30, 40)
+        fakeAreasRepository.area = createTestArea(name = "新宿", updatedDate = LocalDate(2000, 1, 1))
+        fakeLocalImageRepository.loadResult = RunStatus.Success(byteArrayOf(10, 20))
+        fakeFetchAndSaveUnsplashImageUseCase.result = RunStatus.Success(newImageBytes)
+
+        val result = useCase(1)
+
+        assertIs<RunStatus.Success<ByteArray>>(result)
+        assertEquals(newImageBytes, result.data)
+    }
+
+    // --- ローカル画像が存在する + updatedDate が今日または未来の場合 ---
+
+    @Test
+    fun `invoke - ローカル画像があり更新日が未来の場合はUnsplash取得が呼ばれない`() = runTest {
+        fakeAreasRepository.area = createTestArea(name = "池袋", updatedDate = LocalDate(9999, 12, 31))
+        fakeLocalImageRepository.loadResult = RunStatus.Success(byteArrayOf(10, 20))
+
+        useCase(1)
+
+        assertEquals(null, fakeFetchAndSaveUnsplashImageUseCase.invokedQuery)
+    }
+
+    @Test
+    fun `invoke - ローカル画像があり更新日が未来の場合はRunStatus_Errorを返す`() = runTest {
+        fakeAreasRepository.area = createTestArea(name = "池袋", updatedDate = LocalDate(9999, 12, 31))
+        fakeLocalImageRepository.loadResult = RunStatus.Success(byteArrayOf(10, 20))
+
+        val result = useCase(1)
+
+        assertIs<RunStatus.Error<ByteArray>>(result)
+        assertContains(result.message ?: "", "本日は画像を変更できません")
+    }
+
+    // --- areaId の受け渡し ---
+
+    @Test
+    fun `invoke - areaIdがAreasRepositoryに渡される`() = runTest {
+        fakeAreasRepository.area = createTestArea(name = "上野", updatedDate = LocalDate(2000, 1, 1))
+        fakeLocalImageRepository.loadResult = RunStatus.Error("画像なし")
+        fakeFetchAndSaveUnsplashImageUseCase.result = RunStatus.Success(byteArrayOf())
+
+        useCase(42)
+
+        assertEquals(42, fakeAreasRepository.loadedAreaId)
+    }
+
+    // --- ヘルパー ---
+
+    private fun createTestArea(name: String, updatedDate: LocalDate) = Area(
+        areaId = 1,
+        name = name,
+        updatedDate = updatedDate,
+        count = 0,
+        sort = 1
+    )
+
+    // --- フェイク実装 ---
+
+    private class FakeAreasRepository : AreasRepositoryContract {
+        var area: Area? = null
+        var loadedAreaId: Int? = null
+
+        override suspend fun loadByAreaId(areaId: Int): Area? {
+            loadedAreaId = areaId
+            return area
+        }
+
+        override suspend fun load(): List<Area> = emptyList()
+        override suspend fun load(areaName: String): Area? = null
+        override suspend fun add(area: Area) = Unit
+        override suspend fun edit(oldName: String, newName: String): RunStatus<String> = RunStatus.Success("")
+        override suspend fun edit(area: Area): RunStatus<String> = RunStatus.Success("")
+        override suspend fun editAll(areas: List<Area>): RunStatus<String> = RunStatus.Success("")
+        override suspend fun delete(areaName: String): RunStatus<String> = RunStatus.Success("")
+    }
+
+    private class FakeLocalImageRepository : LocalImageRepositoryContract {
+        var loadResult: RunStatus<ByteArray> = RunStatus.Error("未設定")
+
+        override suspend fun load(name: String): RunStatus<ByteArray> = loadResult
+
+        override suspend fun save(imageBytes: ByteArray, name: String) = Unit
+        override suspend fun rename(oldName: String, newName: String) = Unit
+        override suspend fun delete(name: String) = Unit
+    }
+
+    private class FakeFetchAndSaveUnsplashImageUseCase : FetchAndSaveUnsplashImageUseCaseContract {
+        var invokedQuery: String? = null
+        var result: RunStatus<ByteArray> = RunStatus.Success(byteArrayOf())
+
+        override suspend fun invoke(query: String): RunStatus<ByteArray> {
+            invokedQuery = query
+            return result
+        }
+    }
+}


### PR DESCRIPTION
### 概要
HistoryScreenにレポートの検索・フィルター機能とエリア別一覧機能を追加し、パフォーマンス改善とUseCase層のリファクタリングを行った。

### 主な変更点

**1. HistoryScreen 機能拡張**
- 店舗名による検索・フィルター機能を追加
- 年フィルタードロップダウンを追加
- エリア別レポート一覧への遷移を追加
- 検索テキスト状態を State Hoisting で一元管理するようにリファクタリング

**2. パフォーマンス改善**
- LoadFullReports 系 UseCase を Flow 化し、レポートを取得するたびに画面に逐次表示する段階的レンダリングに対応

**3. バグ修正**
- エリア削除時に関連店舗が削除されないバグを修正
- Shop 削除後に areaId が取得できないバグを修正
- AddShopScreen のエラーダイアログ確認後に状態がリセットされないバグを修正

**4. UseCase 層の品質向上**
- AddAreaUseCase を新規作成し ViewModel からの Repository 直接参照を解消
- エリア名の重複チェックを AddAreaUseCase・UpdateAreaUseCase に追加
- Unsplash 画像取得成功時に areas テーブルの updatedDate を更新するよう修正

**5. テストコード追加**
- AreasRepositoryTest、ShopsRepositoryTest を新規追加
- DeleteShopAndImageUseCaseTest、UpdateAreaImageUseCaseTest を新規追加
- AddReportViewModelTest、AddAreaViewModelTest、EditAreaViewModelTest、EditShopViewModelTest を新規追加

### 影響範囲
- 新規ファイル: AddAreaUseCase、LoadFullReportsByArea/Shop/Year UseCase、LoadAreaImageUseCase、各種テストファイル、ボタンコンポーネント群
- 変更ファイル: HistoryScreen、HistoryViewModel、EditAreaViewModel、AddAreaViewModel、FetchAndSaveUnsplashImageUseCase 他多数
- 破壊的変更: なし