### PR TITLE
HistoryScreen遷移時のOOMクラッシュ修正

### DIFF
--- a/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/data/datasource/AndroidLocalStorageDataSource.kt
+++ b/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/data/datasource/AndroidLocalStorageDataSource.kt
@@ -41,6 +41,13 @@ class AndroidLocalStorageDataSource(
             }
         }
 
+    override suspend fun getFilePath(name: String): String? =
+        withContext(Dispatchers.IO) {
+            val fileName = "$name.png"
+            val file = File(context.filesDir, fileName)
+            if (file.exists()) "file://${file.absolutePath}" else null
+        }
+
     override suspend fun rename(oldName: String, newName: String) {
         withContext(Dispatchers.IO) {
             try {

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/datasource/LocalStorageDataSourceContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/datasource/LocalStorageDataSourceContract.kt
@@ -5,6 +5,8 @@ interface LocalStorageDataSourceContract {
 
     suspend fun load(name: String): ByteArray?
 
+    suspend fun getFilePath(name: String): String?
+
     suspend fun rename(oldName: String, newName: String)
 
     suspend fun delete(name: String)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepository.kt
@@ -23,6 +23,11 @@ class LocalImageRepository(
             }
         }
 
+    override suspend fun getFilePath(name: String): String? =
+        withContext(Dispatchers.IO) {
+            localStorageDataSource.getFilePath(name)
+        }
+
     override suspend fun rename(oldName: String, newName: String) {
         withContext(Dispatchers.IO) {
             localStorageDataSource.rename(oldName, newName)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepositoryContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/LocalImageRepositoryContract.kt
@@ -7,6 +7,8 @@ interface LocalImageRepositoryContract {
 
     suspend fun load(name: String): RunStatus<ByteArray>
 
+    suspend fun getFilePath(name: String): String?
+
     suspend fun rename(oldName: String, newName: String)
 
     suspend fun delete(name: String)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/FullReport.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/FullReport.kt
@@ -12,6 +12,7 @@ data class FullReport(
     val impression: String = "",
     val date: LocalDate = createTodayLocalDate(),
     val imageBytes: ByteArray? = null,
+    val imagePath: String? = null,
     val star: Int = 0,
     val areaId: Int = 0
 )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
@@ -4,7 +4,6 @@ import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
-import dev.seabat.ramennote.domain.model.RunStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -19,7 +18,7 @@ class LoadFullReportsByAreaUseCase(
 
             reports.forEach { report ->
                 val shop = shopsRepository.getShopById(report.shopId)
-                val imageBytes = localImageRepository.load(report.photoName)
+                val imagePath = localImageRepository.getFilePath(report.photoName)
                 emit(
                     FullReport(
                         id = report.id,
@@ -27,14 +26,7 @@ class LoadFullReportsByAreaUseCase(
                         shopName = shop?.name ?: "不明な店舗",
                         menuName = report.menuName,
                         photoName = report.photoName,
-                        imageBytes =
-                            when (imageBytes) {
-                                is RunStatus.Success ->
-                                    imageBytes.data
-                                is RunStatus.Error ->
-                                    null
-                                else -> error("unexpected state")
-                            },
+                        imagePath = imagePath,
                         impression = report.impression,
                         date = report.date!!,
                         star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
@@ -4,7 +4,6 @@ import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
-import dev.seabat.ramennote.domain.model.RunStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -19,7 +18,7 @@ class LoadFullReportsByShopUseCase(
 
             reports.forEach { report ->
                 val shop = shopsRepository.getShopById(report.shopId)
-                val imageBytes = localImageRepository.load(report.photoName)
+                val imagePath = localImageRepository.getFilePath(report.photoName)
                 emit(
                     FullReport(
                         id = report.id,
@@ -27,14 +26,7 @@ class LoadFullReportsByShopUseCase(
                         shopName = shop?.name ?: "不明な店舗",
                         menuName = report.menuName,
                         photoName = report.photoName,
-                        imageBytes =
-                            when (imageBytes) {
-                                is RunStatus.Success ->
-                                    imageBytes.data
-                                is RunStatus.Error ->
-                                    null
-                                else -> error("unexpected state")
-                            },
+                        imagePath = imagePath,
                         impression = report.impression,
                         date = report.date!!,
                         star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
@@ -4,7 +4,6 @@ import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
-import dev.seabat.ramennote.domain.model.RunStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -19,7 +18,7 @@ class LoadFullReportsUseCase(
 
             reports.forEach { report ->
                 val shop = shopsRepository.getShopById(report.shopId)
-                val imageBytes = localImageRepository.load(report.photoName)
+                val imagePath = localImageRepository.getFilePath(report.photoName)
                 emit(
                     FullReport(
                         id = report.id,
@@ -27,14 +26,7 @@ class LoadFullReportsUseCase(
                         shopName = shop?.name ?: "不明な店舗",
                         menuName = report.menuName,
                         photoName = report.photoName,
-                        imageBytes =
-                            when (imageBytes) {
-                                is RunStatus.Success ->
-                                    imageBytes.data
-                                is RunStatus.Error ->
-                                    null
-                                else -> error("unexpected state")
-                            },
+                        imagePath = imagePath,
                         impression = report.impression,
                         date = report.date!!,
                         star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
@@ -4,7 +4,6 @@ import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.FullReport
-import dev.seabat.ramennote.domain.model.RunStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -19,7 +18,7 @@ class LoadReportsByYearUseCase(
 
             reports.forEach { report ->
                 val shop = shopsRepository.getShopById(report.shopId)
-                val imageBytes = localImageRepository.load(report.photoName)
+                val imagePath = localImageRepository.getFilePath(report.photoName)
                 emit(
                     FullReport(
                         id = report.id,
@@ -27,14 +26,7 @@ class LoadReportsByYearUseCase(
                         shopName = shop?.name ?: "不明な店舗",
                         menuName = report.menuName,
                         photoName = report.photoName,
-                        imageBytes =
-                            when (imageBytes) {
-                                is RunStatus.Success ->
-                                    imageBytes.data
-                                is RunStatus.Error ->
-                                    null
-                                else -> error("unexpected state")
-                            },
+                        imagePath = imagePath,
                         impression = report.impression,
                         date = report.date!!,
                         star = report.star,

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ReportCard.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ReportCard.kt
@@ -85,7 +85,7 @@ fun ReportCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
             AsyncImage(
-                model = report.imageBytes,
+                model = report.imagePath ?: report.imageBytes,
                 contentDescription = null,
                 modifier =
                     Modifier

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -76,7 +76,7 @@ fun HistoryScreen(
     val yearsState by viewModel.selectableYears.collectAsState()
 
     val listState = rememberLazyListState()
-    var selectedImageBytes by remember { mutableStateOf<ByteArray?>(null) }
+    var selectedImagePath by remember { mutableStateOf<String?>(null) }
     val xShareLauncher = createRememberedXShareLauncher()
     // ReportList 再生成時に渡す初期値（店舗フィルター適用後も検索テキストを保持するため）
     var listSearchText by remember { mutableStateOf(initialSearchText) }
@@ -126,7 +126,7 @@ fun HistoryScreen(
                     years = yearsState,
                     selectedYear = yearState,
                     goToEditReport = goToEditReport,
-                    onDisplayImage = { imageBytes -> selectedImageBytes = imageBytes },
+                    onDisplayImage = { imagePath -> selectedImagePath = imagePath },
                     onFilter = { shop ->
                         // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
                         listSearchText = shop.name
@@ -194,10 +194,10 @@ fun HistoryScreen(
             }
 
             // 画像ダイアログ
-            selectedImageBytes?.let { imageBytes ->
+            selectedImagePath?.let { path ->
                 ReportImageDialog(
-                    imageBytes = imageBytes,
-                    onDismiss = { selectedImageBytes = null }
+                    model = path,
+                    onDismiss = { selectedImagePath = null }
                 )
             }
         } else {
@@ -286,7 +286,7 @@ private fun ReportList(
     years: List<Int>,
     selectedYear: String,
     goToEditReport: (Int) -> Unit,
-    onDisplayImage: (ByteArray?) -> Unit,
+    onDisplayImage: (String?) -> Unit,
     onFilter: (Shop) -> Unit = {},
     onShare: (String, ByteArray?) -> Unit,
     onSearchTextChange: (String) -> Unit = {},
@@ -368,7 +368,7 @@ private fun ReportList(
                         report = report,
                         isSimpleDisplay = false,
                         onLongPress = { goToEditReport(report.id) },
-                        onImageTap = { onDisplayImage(report.imageBytes) },
+                        onImageTap = { onDisplayImage(report.imagePath) },
                         onTap = {},
                         onShareTap = onShare
                     )

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/ReportImageDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/ReportImageDialog.kt
@@ -13,9 +13,19 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.seabat.ramennote.ui.components.dialog.WideDialog
 
+/**
+ * 食レポの画像をフルサイズで表示するダイアログ。
+ *
+ * [WideDialog] 上に [AsyncImage] を配置し、画像を画面幅いっぱいに引き伸ばさず
+ * アスペクト比を維持したまま表示する。
+ *
+ * @param model Coil に渡す画像モデル。`file://` 形式の URI 文字列または [ByteArray] を受け付ける。
+ *              `null` の場合は何も表示されない。
+ * @param onDismiss ダイアログを閉じる際に呼び出されるコールバック。
+ */
 @Composable
 fun ReportImageDialog(
-    imageBytes: ByteArray?,
+    model: Any?,
     onDismiss: () -> Unit
 ) {
     WideDialog(onDismiss = onDismiss) {
@@ -27,7 +37,7 @@ fun ReportImageDialog(
             contentAlignment = Alignment.Center
         ) {
             AsyncImage(
-                model = imageBytes,
+                model = model,
                 contentDescription = null,
                 modifier =
                     Modifier

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -268,7 +268,7 @@ fun HomeScreen(
         // 画像ダイアログ
         selectedImageBytes?.let { imageBytes ->
             ReportImageDialog(
-                imageBytes = imageBytes,
+                model = imageBytes,
                 onDismiss = { selectedImageBytes = null }
             )
         }

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/DeleteShopAndImageUseCaseTest.kt
@@ -204,6 +204,7 @@ class DeleteShopAndImageUseCaseTest {
 
         override suspend fun save(imageBytes: ByteArray, name: String) = Unit
         override suspend fun load(name: String): RunStatus<ByteArray> = RunStatus.Error("未実装")
+        override suspend fun getFilePath(name: String): String? = null
         override suspend fun rename(oldName: String, newName: String) = Unit
     }
 

--- a/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaImageUseCaseTest.kt
@@ -168,6 +168,7 @@ class UpdateAreaImageUseCaseTest {
         override suspend fun load(name: String): RunStatus<ByteArray> = loadResult
 
         override suspend fun save(imageBytes: ByteArray, name: String) = Unit
+        override suspend fun getFilePath(name: String): String? = null
         override suspend fun rename(oldName: String, newName: String) = Unit
         override suspend fun delete(name: String) = Unit
     }

--- a/iosApp/iosApp/Kmp/IosLocalStorageDataSource.swift
+++ b/iosApp/iosApp/Kmp/IosLocalStorageDataSource.swift
@@ -50,6 +50,15 @@ class IosLocalStorageDataSource: LocalStorageDataSourceContract {
         }
     }
 
+    func __getFilePath(name: String) async throws -> String? {
+        guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let fileName = "\(name).png"
+        let fileURL = documentsPath.appendingPathComponent(fileName)
+        return FileManager.default.fileExists(atPath: fileURL.path) ? fileURL.absoluteString : nil
+    }
+
     func __rename(oldName: String, newName: String) async throws {
         do {
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first


### PR DESCRIPTION
### 概要

HistoryScreen に遷移すると全レポートの画像を ByteArray として一括ロードするため、レポート数が多い場合に OutOfMemoryError でクラッシュする問題を修正する。

### 主な変更点

**1. 画像の遅延ロード化**
- リスト表示用の UseCase（LoadFullReportsUseCase 系 4 本）で画像 ByteArray のロードを廃止し、ファイルパス（`file://` URI）の取得に変更
- `FullReport` に `imagePath: String?` フィールドを追加
- `ReportCard` のサムネイル表示を `imagePath` 優先に変更し、Coil のメモリ管理に委ねる

**2. ファイルパス取得の追加**
- `LocalStorageDataSourceContract` / `LocalImageRepositoryContract` に `getFilePath()` メソッドを追加
- Android・iOS 両実装に対応する `getFilePath()` を追加

**3. 画像ダイアログの汎用化**
- `ReportImageDialog` の引数を `imageBytes: ByteArray?` から `model: Any?` に変更し、URI 文字列と ByteArray の両方を受け付けるよう対応
- HistoryScreen のダイアログ表示を `imagePath` 経由に変更

### 影響範囲
- 変更ファイル: `LocalStorageDataSourceContract`, `LocalImageRepositoryContract`, `LocalImageRepository`, `AndroidLocalStorageDataSource`, `IosLocalStorageDataSource.swift`, `FullReport`, `LoadFullReportsUseCase` 系 4 本, `ReportCard`, `ReportImageDialog`, `HistoryScreen`, `HomeScreen`
- 破壊的変更: `ReportImageDialog` のパラメータ名が `imageBytes` から `model` に変更（HomeScreen 側も対応済み）