### PR TITLE
Firebase App Check 導入とスプラッシュスクリーン修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ RamenNote は、ラーメン店の情報をエリア別に管理し、訪問予�
 - **Coil**: 画像読み込み
 - **Navigation Compose**: 画面遷移
 - **SKIE**: Kotlin/Swift 連携（iOS）
-- **Firebase**: Analytics・Crashlytics・AI（Android）
+- **Firebase**: Analytics・Crashlytics・AI・App Check（Android: Play Integrity / Debug、iOS: DeviceCheck / Debug）
 - **Gemini AI**: AI 機能（Android）
 
 ### 開発環境
@@ -100,6 +100,15 @@ UNSPLASH_ACCESS_KEY=取得した Access Key
 ビルド時に Gradle が `local.properties` から値を読み込み、commonMain 向けに `BuildSecrets.kt` を自動生成します。アプリコードは `BuildSecrets.UNSPLASH_ACCESS_KEY` 経由で参照します。
 
 **注意**: Access Key を設定せずにビルドすると、エリア画像の取得が正常に動作しません。
+
+### Firebase App Check の設定
+
+Firebase App Check によって不正クライアントからの API アクセスを防いでいます。詳細は [`docs/firebase-api-security.md`](./docs/firebase-api-security.md) を参照してください。
+
+| プラットフォーム | 本番ビルド | デバッグビルド |
+|----------------|-----------|--------------|
+| Android | Play Integrity | Debug プロバイダー |
+| iOS | DeviceCheck | Debug プロバイダー |
 
 ### ビルドと実行
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -139,8 +139,8 @@ android {
         applicationId = "dev.seabat.ramennote"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 18
-        versionName = "1.1.0"
+        versionCode = 19
+        versionName = "1.1.1"
     }
     buildFeatures {
         buildConfig = true

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
             implementation(libs.firebase.ai)
             implementation(libs.firebase.analytics)
             implementation(libs.firebase.crashlytics)
+            implementation(libs.firebase.appcheck)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -164,6 +165,7 @@ android {
 
 dependencies {
     debugImplementation(compose.uiTooling)
+    debugImplementation(libs.firebase.appcheck.debug)
 
     add("kspAndroid", libs.androidx.room.compiler)
     add("kspIosSimulatorArm64", libs.androidx.room.compiler)

--- a/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/RamenNoteApplication.kt
+++ b/composeApp/src/androidMain/kotlin/dev/seabat/ramennote/RamenNoteApplication.kt
@@ -1,6 +1,12 @@
 package dev.seabat.ramennote
 
 import android.app.Application
+import com.google.firebase.Firebase
+import com.google.firebase.appcheck.appCheck
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+import com.google.firebase.initialize
+import dev.seabat.ramennote.BuildConfig
 import dev.seabat.ramennote.data.di.dataSourceModule
 import dev.seabat.ramennote.data.di.databaseModule
 import dev.seabat.ramennote.data.di.factoryModule
@@ -14,6 +20,16 @@ import org.koin.core.context.GlobalContext.startKoin
 class RamenNoteApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        // Firebase App Check の初期化
+        Firebase.initialize(this)
+        Firebase.appCheck.installAppCheckProviderFactory(
+            if (BuildConfig.DEBUG) {
+                DebugAppCheckProviderFactory.getInstance()
+            } else {
+                PlayIntegrityAppCheckProviderFactory.getInstance()
+            }
+        )
 
         startKoin {
             androidContext(this@RamenNoteApplication)

--- a/composeApp/src/androidMain/res/drawable/ic_splash_icon.xml
+++ b/composeApp/src/androidMain/res/drawable/ic_splash_icon.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- スプラッシュスクリーン用アイコン
      Android 12+: 全体 288dp / セーフゾーン（クリップ円）192dp
-     アイコン画像は 160dp に収めてクリップを回避 -->
+     アイコン画像は 100dp に収めてクリップを回避 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:width="160dp"
-        android:height="160dp"
+        android:width="100dp"
+        android:height="100dp"
         android:gravity="center">
         <bitmap
             android:src="@drawable/ic_splash_raw"

--- a/docs/firebase-api-security.md
+++ b/docs/firebase-api-security.md
@@ -3,7 +3,37 @@
 ## 概要
 
 `google-services.json` をパブリックリポジトリで管理するにあたり、
-Google Cloud Console にて以下のセキュリティ設定を実施済み。
+Google Cloud Console および Firebase Console にて以下のセキュリティ設定を実施済み。
+
+---
+
+## Firebase App Check
+
+アプリの正当性を検証し、不正なクライアントからの API アクセスを防ぐ。
+
+### 背景
+
+`GenerativeBackend.googleAI()` 経由のリクエストは Firebase サーバー経由でプロキシされるため、
+GCP の API キーに Android/iOS アプリ制限を設定しても効果がない（リクエスト元が Firebase サーバーになるため）。
+そのため Firebase App Check によるアクセス保護に切り替えた。
+
+### プロバイダー設定
+
+| プラットフォーム | 本番ビルド | デバッグビルド |
+|----------------|-----------|--------------|
+| Android | Play Integrity | Debug プロバイダー |
+| iOS | DeviceCheck | Debug プロバイダー |
+
+### 実装
+
+- **Android**: `RamenNoteApplication.onCreate()` で `BuildConfig.DEBUG` により切り替え
+- **iOS**: `iOSApp.init()` で `#if DEBUG` により切り替え（`FirebaseApp.configure()` より前に設定）
+
+### Firebase Console での設定
+
+Firebase Console → App Check → APIs にて以下の API の適用を有効化：
+
+- Firebase AI Logic（Gemini へのアクセスを App Check で保護）
 
 ---
 
@@ -11,11 +41,12 @@ Google Cloud Console にて以下のセキュリティ設定を実施済み。
 
 ### Android API キー
 
-| 項目 | 設定値                                                                                  |
-|------|--------------------------------------------------------------------------------------|
-| 制限の種類 | Android アプリ                                                                          |
-| パッケージ名 | `dev.seabat.ramennote`                                                               |
+| 項目 | 設定値 |
+|------|--------|
+| 制限の種類 | Android アプリ |
+| パッケージ名 | `dev.seabat.ramennote` |
 | SHA-1 証明書フィンガープリント | デバッグ用(~/.android/debug.keystore から取得)・リリース用(Play Console に登録しているアプリ署名鍵の証明書から取得)を登録済み |
+| API の制限 | Generative Language API、Firebase App Check API を許可 |
 
 ### iOS API キー
 
@@ -23,6 +54,10 @@ Google Cloud Console にて以下のセキュリティ設定を実施済み。
 |------|--------|
 | 制限の種類 | iOS アプリ |
 | Bundle ID | `dev.seabat.ramennote` |
+| API の制限 | Generative Language API、Firebase App Check API を許可 |
+
+> **備考**: App Check のデバッグトークン交換（`firebaseappcheck.googleapis.com`）が
+> Android/iOS API キー経由で行われるため、各キーの許可リストに `Firebase App Check API` を追加済み。
 
 ---
 
@@ -30,12 +65,22 @@ Google Cloud Console にて以下のセキュリティ設定を実施済み。
 
 | 項目 | 設定値 |
 |------|--------|
-| API の制限 | Generative Language API のみ許可 |
-| アプリケーションの制限 | 設定なし（Android/iOS キーで制御済みのため不要） |
+| API の制限 | 制限なし（デフォルト） |
+| アプリケーションの制限 | 設定なし |
 
-> **備考**: アプリは `GenerativeBackend.googleAI()` を使用しており、
-> Gemini Developer API（`generativelanguage.googleapis.com`）のグローバルエンドポイントを利用している。
-> Vertex AI は使用していない。
+> **備考**: アプリは `GenerativeBackend.googleAI()` を使用しており、リクエストは Firebase サーバー経由でプロキシされる。
+>
+> ```
+> アプリ
+>   ↓（Firebase API キー + App Check トークン）
+> Firebase サーバー
+>   ↓（Gemini Developer API キー）← Firebase が使用
+> Gemini API（generativelanguage.googleapis.com）
+> ```
+>
+> アプリがこのキーを直接使うわけではないが、Firebase が Gemini を呼び出す際にサーバー側で使用する。
+> Firebase がプロジェクト設定時に自動生成したキーであり、アプリ側での管理は不要。
+> エンドユーザーからのアクセス保護は Firebase App Check（Android: Play Integrity、iOS: DeviceCheck）が担う。
 
 ---
 
@@ -56,4 +101,5 @@ Google Cloud Console → API とサービス → Generative Language API → 割
 
 ## 設定日
 
-2026-03-22
+- 2026-03-22: API キー制限・クォータ設定
+- 2026-03-23: Firebase App Check 導入

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,8 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-ai = { module = "com.google.firebase:firebase-ai" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-appcheck = { module = "com.google.firebase:firebase-appcheck-playintegrity" }
+firebase-appcheck-debug = { module = "com.google.firebase:firebase-appcheck-debug" }
 
 
 [plugins]

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		11CEFE212EE041C600156A0D /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE202EE041C600156A0D /* FirebaseAI */; };
 		11CEFE232EE041C600156A0D /* FirebaseAILogic in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE222EE041C600156A0D /* FirebaseAILogic */; };
 		11CEFE272EE043C900156A0D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE262EE043C900156A0D /* FirebaseAnalytics */; };
+		A1B2C3D4E5F601230000AAAA /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F601230000BBBB /* FirebaseAppCheck */; };
 		11D36B5E2F495C8800BE5B60 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 11D36B5D2F495C8800BE5B60 /* FirebaseCrashlytics */; };
 /* End PBXBuildFile section */
 
@@ -52,6 +53,7 @@
 				11D36B5E2F495C8800BE5B60 /* FirebaseCrashlytics in Frameworks */,
 				11CEFE212EE041C600156A0D /* FirebaseAI in Frameworks */,
 				11CEFE272EE043C900156A0D /* FirebaseAnalytics in Frameworks */,
+				A1B2C3D4E5F601230000AAAA /* FirebaseAppCheck in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,6 +110,7 @@
 				11CEFE222EE041C600156A0D /* FirebaseAILogic */,
 				11CEFE262EE043C900156A0D /* FirebaseAnalytics */,
 				11D36B5D2F495C8800BE5B60 /* FirebaseCrashlytics */,
+				A1B2C3D4E5F601230000BBBB /* FirebaseAppCheck */,
 			);
 			productName = iosApp;
 			productReference = 793FCED0C6C7E4F57A4AEDA2 /* RamenNote.app */;
@@ -443,6 +446,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 11CEFE1F2EE041C600156A0D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
+		};
+		A1B2C3D4E5F601230000BBBB /* FirebaseAppCheck */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 11CEFE1F2EE041C600156A0D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAppCheck;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		11CEFE212EE041C600156A0D /* FirebaseAI in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE202EE041C600156A0D /* FirebaseAI */; };
 		11CEFE232EE041C600156A0D /* FirebaseAILogic in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE222EE041C600156A0D /* FirebaseAILogic */; };
 		11CEFE272EE043C900156A0D /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 11CEFE262EE043C900156A0D /* FirebaseAnalytics */; };
-		A1B2C3D4E5F601230000AAAA /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F601230000BBBB /* FirebaseAppCheck */; };
 		11D36B5E2F495C8800BE5B60 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 11D36B5D2F495C8800BE5B60 /* FirebaseCrashlytics */; };
+		A1B2C3D4E5F601230000AAAA /* FirebaseAppCheck in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F601230000BBBB /* FirebaseAppCheck */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -205,7 +205,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -221,7 +221,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -241,7 +241,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -257,7 +257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,12 +1,21 @@
 import ComposeApp
 import SwiftUI
 import FirebaseCore
+import FirebaseAppCheck
 
 @main
 struct iOSApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
+        // Firebase App Check の初期化（FirebaseApp.configure() より前に設定）
+        #if DEBUG
+        let providerFactory = AppCheckDebugProviderFactory()
+        #else
+        let providerFactory = DeviceCheckProviderFactory()
+        #endif
+        AppCheck.setAppCheckProviderFactory(providerFactory)
+
         FirebaseApp.configure()
 
         KoinHelperKt.doInitKoin(


### PR DESCRIPTION
### 概要

Firebase AI Logic の API キー制限が Android/iOS アプリ制限では機能しない問題を解消するため、Firebase App Check を導入した。あわせてスプラッシュスクリーンのロゴが欠けて表示される問題を修正した。

### 主な変更点

**1. Firebase App Check の導入**
- Android: 本番ビルドは Play Integrity、デバッグビルドは Debug プロバイダーを使用
- iOS: 本番ビルドは DeviceCheck、デバッグビルドは Debug プロバイダーを使用
- `RamenNoteApplication.onCreate()` で `BuildConfig.DEBUG` により切り替え初期化
- `iOSApp.init()` で `#if DEBUG` により切り替え初期化（`FirebaseApp.configure()` より前）

**2. API キー設定の更新**
- Android/iOS API キーの許可リストに Firebase App Check API を追加
- セキュリティ設定ドキュメント（`docs/firebase-api-security.md`）を更新

**3. スプラッシュスクリーンのロゴサイズ修正**
- Android スプラッシュスクリーンのロゴが欠けて表示される問題を修正
- アイコンサイズを 160dp → 100dp に縮小

**4. バージョン更新**
- versionCode: 18 → 19、versionName: 1.1.0 → 1.1.1

### 影響範囲
- 新規ファイル: なし
- 変更ファイル: `RamenNoteApplication.kt`、`iOSApp.swift`、`build.gradle.kts`、`libs.versions.toml`、`project.pbxproj`、`ic_splash_icon.xml`、`docs/firebase-api-security.md`、`README.md`
- 破壊的変更: なし