### PR TITLE
食レポ・予定画面への食レポ追加 FAB と店舗選択ダイアログの追加

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -136,6 +136,14 @@
     <string name="editreport_delete_button">削除する</string>
     <string name="editreport_edit_button">編集する</string>
 
+    <!-- Select Shop Dialog -->
+    <string name="select_shop_dialog_title">店舗を選択</string>
+    <string name="select_shop_dialog_area_label">エリア</string>
+    <string name="select_shop_dialog_shop_label">店舗</string>
+    <string name="select_shop_dialog_cancel_button">キャンセル</string>
+    <string name="select_shop_dialog_write_report_button">食レポを書く</string>
+    <string name="select_shop_dialog_create_schedule_button">予定を作成</string>
+
     <!-- History Screen -->
     <string name="history_no_data">食レポがありません。\n「ノート」の店舗画面に遷移し、食レポを登録してください。</string>
     <string name="history_year">年</string>

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -46,6 +46,8 @@ import dev.seabat.ramennote.domain.usecase.LoadImagePathUseCase
 import dev.seabat.ramennote.domain.usecase.LoadImagePathUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCase
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadRecentFullReportsUseCase
+import dev.seabat.ramennote.domain.usecase.LoadRecentFullReportsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCase
 import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCase
@@ -56,8 +58,6 @@ import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCase
 import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCase
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
-import dev.seabat.ramennote.domain.usecase.LoadRecentFullReportsUseCase
-import dev.seabat.ramennote.domain.usecase.LoadRecentFullReportsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadYearlyReportStatsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadYearlyReportStatsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SearchShopsByNameUseCase

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddFab.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddFab.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun AddFab(
     modifier: Modifier = Modifier,
+    contentDescription: String = "追加",
     onAddClick: () -> Unit
 ) {
     FloatingActionButton(
@@ -23,7 +24,7 @@ fun AddFab(
     ) {
         Icon(
             imageVector = Icons.Default.Add,
-            contentDescription = "追加"
+            contentDescription = contentDescription
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/SelectShopDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/SelectShopDialog.kt
@@ -1,4 +1,4 @@
-package dev.seabat.ramennote.ui.screens.history
+package dev.seabat.ramennote.ui.components.dialog
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,17 +29,28 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.Shop
-import dev.seabat.ramennote.ui.components.dialog.WideDialog
 import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
+import dev.seabat.ramennote.ui.screens.history.MockSelectShopViewModel
+import dev.seabat.ramennote.ui.screens.history.MockSelectShopViewModelWithData
+import dev.seabat.ramennote.ui.screens.history.SelectShopViewModel
+import dev.seabat.ramennote.ui.screens.history.SelectShopViewModelContract
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import ramennote.composeapp.generated.resources.Res
+import ramennote.composeapp.generated.resources.select_shop_dialog_area_label
+import ramennote.composeapp.generated.resources.select_shop_dialog_cancel_button
+import ramennote.composeapp.generated.resources.select_shop_dialog_shop_label
+import ramennote.composeapp.generated.resources.select_shop_dialog_title
+import ramennote.composeapp.generated.resources.select_shop_dialog_write_report_button
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectShopDialog(
     onDismiss: () -> Unit,
-    onReportClick: (Shop) -> Unit,
+    confirmButtonLabel: String,
+    onConfirmClick: (Shop) -> Unit,
     viewModel: SelectShopViewModelContract = koinViewModel<SelectShopViewModel>()
 ) {
     val areas by viewModel.areas.collectAsStateWithLifecycle()
@@ -60,7 +71,7 @@ fun SelectShopDialog(
                     .padding(horizontal = 16.dp)
         ) {
             Text(
-                text = "店舗を選択",
+                text = stringResource(Res.string.select_shop_dialog_title),
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
@@ -68,7 +79,7 @@ fun SelectShopDialog(
             // エリアドロップダウン
             Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {
                 Text(
-                    text = "エリア",
+                    text = stringResource(Res.string.select_shop_dialog_area_label),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -117,7 +128,7 @@ fun SelectShopDialog(
                         .alpha(if (shopEnabled) 1f else 0.38f)
             ) {
                 Text(
-                    text = "店舗",
+                    text = stringResource(Res.string.select_shop_dialog_shop_label),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -161,14 +172,14 @@ fun SelectShopDialog(
                 horizontalArrangement = Arrangement.End
             ) {
                 TextButton(onClick = onDismiss) {
-                    Text("キャンセル")
+                    Text(stringResource(Res.string.select_shop_dialog_cancel_button))
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(
-                    onClick = { selectedShop?.let { onReportClick(it) } },
+                    onClick = { selectedShop?.let { onConfirmClick(it) } },
                     enabled = selectedShop != null
                 ) {
-                    Text("レポートを書く")
+                    Text(confirmButtonLabel)
                 }
             }
 
@@ -183,7 +194,8 @@ private fun SelectShopDialogPreview() {
     RamenNoteTheme {
         SelectShopDialog(
             onDismiss = {},
-            onReportClick = {},
+            confirmButtonLabel = stringResource(Res.string.select_shop_dialog_write_report_button),
+            onConfirmClick = {},
             viewModel = MockSelectShopViewModel()
         )
     }
@@ -195,7 +207,8 @@ private fun SelectShopDialogWithDataPreview() {
     RamenNoteTheme {
         SelectShopDialog(
             onDismiss = {},
-            onReportClick = {},
+            confirmButtonLabel = stringResource(Res.string.select_shop_dialog_write_report_button),
+            onConfirmClick = {},
             viewModel = MockSelectShopViewModelWithData()
         )
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/WideDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/WideDialog.kt
@@ -67,8 +67,8 @@ fun WideDialog(
                 modifier =
                     Modifier
                         .align(Alignment.TopEnd)
-                        .offset(x = 16.dp, y = (-16).dp) // コンテンツBoxの右上角に配置（右方向に調整）
-                        .size(32.dp)
+                        .offset(x = 24.dp, y = (-24).dp) // コンテンツBoxの右上角に配置（右方向に調整）
+                        .size(48.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.background)
                         .border(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dropdown/DropdownAnchorField.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dropdown/DropdownAnchorField.kt
@@ -1,0 +1,77 @@
+package dev.seabat.ramennote.ui.components.dropdown
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.dp
+
+/**
+ * ドロップダウンのアンカーフィールド。
+ *
+ * ## OutlinedTextField を使用しない理由
+ * `OutlinedTextField` は内部 padding が大きく、隣接する `SearchInputField` と高さが合わなくなる。
+ * HistoryScreen の `YearDropdownField` と `SearchInputField` は同一行に並んでおり、
+ * 高さの一致が設計上の要件となっている。
+ * また、表示内容はヒントテキストで示しているため、`OutlinedTextField` のフローティングラベルは不要。
+ *
+ * 見た目を変更する場合は `BasicTextField` + 手動ボーダーの構造を維持したまま、
+ * ボーダー色・テキスト色を手動で制御すること。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DropdownAnchorField(
+    text: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier =
+            modifier
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                    shape = RoundedCornerShape(4.dp)
+                ).clickable { onToggle() }
+    ) {
+        // テキスト入力領域（読み取り専用として扱う）
+        BasicTextField(
+            value = text,
+            onValueChange = { /* readOnly */ },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 12.dp, end = 28.dp, top = 8.dp, bottom = 8.dp) // 右側にアイコン分の余白
+                    .focusable(false),
+            readOnly = true,
+            singleLine = true,
+            textStyle =
+                MaterialTheme.typography.bodyLarge.copy(
+                    color = MaterialTheme.colorScheme.onSurface
+                ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
+        )
+
+        // 末尾のドロップダウンアイコン
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 4.dp)
+        ) {
+            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
@@ -1,6 +1,7 @@
 package dev.seabat.ramennote.ui.di
 
 import dev.seabat.ramennote.ui.screens.history.HistoryViewModel
+import dev.seabat.ramennote.ui.screens.history.SelectShopViewModel
 import dev.seabat.ramennote.ui.screens.history.addreport.AddReportViewModel
 import dev.seabat.ramennote.ui.screens.history.editreport.EditReportViewModel
 import dev.seabat.ramennote.ui.screens.home.HomeViewModel
@@ -27,6 +28,7 @@ val viewModelModule =
         viewModel { EditReportViewModel(get(), get(), get(), get()) }
         viewModel { EditShopViewModel(get(), get(), get(), get()) }
         viewModel { HistoryViewModel(get(), get(), get(), get(), get(), get(), get()) }
+        viewModel { SelectShopViewModel(get(), get()) }
         viewModel { HomeViewModel(get(), get(), get(), get(), get(), get(), get()) }
         viewModel { NoteViewModel(get(), get(), get()) }
         viewModel { AddReportViewModel(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
@@ -463,6 +463,9 @@ fun MainNavigation() {
                             goToEditReport = { reportId ->
                                 navController.navigate(Screen.EditReport(reportId))
                             },
+                            goToReport = { shopId, shopName, menuName, iso8601Date ->
+                                navController.navigate(Screen.Report(shopId, shopName, menuName, iso8601Date))
+                            },
                             clearReportIdParam = {
                                 reportIdParam = null
                             },

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
@@ -1,21 +1,14 @@
 package dev.seabat.ramennote.ui.screens.componens
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
@@ -26,10 +19,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -81,53 +74,6 @@ fun ShopDropdownField(
                     )
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun DropdownAnchorField(
-    text: String,
-    expanded: Boolean,
-    onToggle: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier =
-            modifier
-                .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outline,
-                    shape = RoundedCornerShape(4.dp)
-                ).clickable { onToggle() }
-    ) {
-        // テキスト入力領域（読み取り専用として扱う）
-        BasicTextField(
-            value = text,
-            onValueChange = { /* readOnly */ },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 12.dp, end = 28.dp, top = 8.dp, bottom = 8.dp) // 右側にアイコン分の余白
-                    .focusable(false),
-            readOnly = true,
-            singleLine = true,
-            textStyle =
-                MaterialTheme.typography.bodyLarge.copy(
-                    color = MaterialTheme.colorScheme.onSurface
-                ),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
-        )
-
-        // 末尾のドロップダウンアイコン
-        Box(
-            modifier =
-                Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = 4.dp)
-        ) {
-            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
@@ -1,18 +1,23 @@
 package dev.seabat.ramennote.ui.screens.componens
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -55,6 +61,7 @@ fun ShopDropdownField(
             DropdownAnchorField(
                 text = value,
                 expanded = expanded,
+                onToggle = { expanded = !expanded },
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -78,36 +85,51 @@ fun ShopDropdownField(
     }
 }
 
-/**
- * ドロップダウンのアンカーとなる読み取り専用フィールド。
- *
- * [OutlinedTextField] ベースで MD3 の enabled/disabled スタイルを自動適用する。
- * [ExposedDropdownMenuBox] の直接の子として使用し、[Modifier.menuAnchor] を渡すこと。
- *
- * @param text 表示するテキスト
- * @param expanded ドロップダウンが展開中かどうか（TrailingIcon の回転に使用）
- * @param label フィールド内に表示するラベル。null の場合はラベルなし
- * @param enabled false にすると MD3 の disabled スタイルが自動適用される
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DropdownAnchorField(
     text: String,
     expanded: Boolean,
-    label: String? = null,
-    enabled: Boolean = true,
+    onToggle: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    OutlinedTextField(
-        value = text,
-        onValueChange = {},
-        readOnly = true,
-        enabled = enabled,
-        label = label?.let { { Text(it) } },
-        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-        modifier = modifier,
-        singleLine = true
-    )
+    Box(
+        modifier =
+            modifier
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                    shape = RoundedCornerShape(4.dp)
+                ).clickable { onToggle() }
+    ) {
+        // テキスト入力領域（読み取り専用として扱う）
+        BasicTextField(
+            value = text,
+            onValueChange = { /* readOnly */ },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 12.dp, end = 28.dp, top = 8.dp, bottom = 8.dp) // 右側にアイコン分の余白
+                    .focusable(false),
+            readOnly = true,
+            singleLine = true,
+            textStyle =
+                MaterialTheme.typography.bodyLarge.copy(
+                    color = MaterialTheme.colorScheme.onSurface
+                ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
+        )
+
+        // 末尾のドロップダウンアイコン
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 4.dp)
+        ) {
+            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+        }
+    }
 }
 
 @Preview(showBackground = true)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
@@ -1,23 +1,18 @@
 package dev.seabat.ramennote.ui.screens.componens
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -61,7 +55,6 @@ fun ShopDropdownField(
             DropdownAnchorField(
                 text = value,
                 expanded = expanded,
-                onToggle = { expanded = !expanded },
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -85,51 +78,36 @@ fun ShopDropdownField(
     }
 }
 
+/**
+ * ドロップダウンのアンカーとなる読み取り専用フィールド。
+ *
+ * [OutlinedTextField] ベースで MD3 の enabled/disabled スタイルを自動適用する。
+ * [ExposedDropdownMenuBox] の直接の子として使用し、[Modifier.menuAnchor] を渡すこと。
+ *
+ * @param text 表示するテキスト
+ * @param expanded ドロップダウンが展開中かどうか（TrailingIcon の回転に使用）
+ * @param label フィールド内に表示するラベル。null の場合はラベルなし
+ * @param enabled false にすると MD3 の disabled スタイルが自動適用される
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DropdownAnchorField(
     text: String,
     expanded: Boolean,
-    onToggle: () -> Unit,
+    label: String? = null,
+    enabled: Boolean = true,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier =
-            modifier
-                .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outline,
-                    shape = RoundedCornerShape(4.dp)
-                ).clickable { onToggle() }
-    ) {
-        // テキスト入力領域（読み取り専用として扱う）
-        BasicTextField(
-            value = text,
-            onValueChange = { /* readOnly */ },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 12.dp, end = 28.dp, top = 8.dp, bottom = 8.dp) // 右側にアイコン分の余白
-                    .focusable(false),
-            readOnly = true,
-            singleLine = true,
-            textStyle =
-                MaterialTheme.typography.bodyLarge.copy(
-                    color = MaterialTheme.colorScheme.onSurface
-                ),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary)
-        )
-
-        // 末尾のドロップダウンアイコン
-        Box(
-            modifier =
-                Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = 4.dp)
-        ) {
-            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-        }
-    }
+    OutlinedTextField(
+        value = text,
+        onValueChange = {},
+        readOnly = true,
+        enabled = enabled,
+        label = label?.let { { Text(it) } },
+        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+        modifier = modifier,
+        singleLine = true
+    )
 }
 
 @Preview(showBackground = true)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -102,12 +102,7 @@ fun HistoryScreen(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(vertical = 8.dp, horizontal = 16.dp)
-        ) {
+        Column(modifier = Modifier.fillMaxSize()) {
             AppBar(
                 title =
                     when {
@@ -120,118 +115,127 @@ fun HistoryScreen(
                         else -> stringResource(Res.string.screen_history_title)
                     }
             )
-            if (reportsState.isNotEmpty()) {
-                Box {
-                    // レポート一覧
-                    ReportList(
-                        reports = reportsState,
-                        listState = listState,
-                        searchText = listSearchText,
-                        isSearchResultVisible = listIsSearchResultVisible,
-                        shops = shops,
-                        years = yearsState,
-                        selectedYear = yearState,
-                        goToEditReport = goToEditReport,
-                        onDisplayImage = { imagePath -> selectedImagePath = imagePath },
-                        onFilter = { shop ->
-                            // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
-                            listSearchText = shop.name
-                            listIsSearchResultVisible = false
-                            viewModel.loadReportsByShop(shop.id)
-                        },
-                        onShare = { postText, photoName ->
-                            viewModel.shareToX(
-                                postText = postText,
-                                photoName = photoName,
-                                xShareLauncher = xShareLauncher
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (reportsState.isNotEmpty()) {
+                        Box {
+                            // レポート一覧
+                            ReportList(
+                                reports = reportsState,
+                                listState = listState,
+                                searchText = listSearchText,
+                                isSearchResultVisible = listIsSearchResultVisible,
+                                shops = shops,
+                                years = yearsState,
+                                selectedYear = yearState,
+                                goToEditReport = goToEditReport,
+                                onDisplayImage = { imagePath -> selectedImagePath = imagePath },
+                                onFilter = { shop ->
+                                    // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
+                                    listSearchText = shop.name
+                                    listIsSearchResultVisible = false
+                                    viewModel.loadReportsByShop(shop.id)
+                                },
+                                onShare = { postText, photoName ->
+                                    viewModel.shareToX(
+                                        postText = postText,
+                                        photoName = photoName,
+                                        xShareLauncher = xShareLauncher
+                                    )
+                                },
+                                onSearchTextChange = { text ->
+                                    listSearchText = text
+                                    if (text.isNotEmpty()) {
+                                        listIsSearchResultVisible = true
+                                        viewModel.searchShops(text)
+                                    } else {
+                                        listIsSearchResultVisible = false
+                                        viewModel.loadReports()
+                                    }
+                                },
+                                onYearSelect = { year ->
+                                    listSearchText = ""
+                                    listIsSearchResultVisible = false
+                                    viewModel.loadReportsByYear(year)
+                                },
+                                onClearYearFilter = { viewModel.loadReports() }
                             )
-                        },
-                        onSearchTextChange = { text ->
-                            listSearchText = text
-                            if (text.isNotEmpty()) {
-                                listIsSearchResultVisible = true
-                                viewModel.searchShops(text)
-                            } else {
-                                listIsSearchResultVisible = false
-                                viewModel.loadReports()
-                            }
-                        },
-                        onYearSelect = { year ->
-                            listSearchText = ""
-                            listIsSearchResultVisible = false
-                            viewModel.loadReportsByYear(year)
-                        },
-                        onClearYearFilter = { viewModel.loadReports() }
-                    )
-                }
-
-                // reportIdが指定されている場合、該当アイテムまで自動スクロール
-                // キーを reportId のみにして、レポートが1件ずつ追加されるたびに
-                // LaunchedEffect が再起動・キャンセルされる問題を防ぐ
-                LaunchedEffect(reportId) {
-                    val id = reportId ?: return@LaunchedEffect
-
-                    // 全件読み込み完了を待つ（reportsStateが変化しなくなるまで）
-                    var lastSize = -1
-                    while (reportsState.size != lastSize) {
-                        lastSize = reportsState.size
-                        delay(100)
-                    }
-                    if (reportsState.isEmpty()) {
-                        clearReportIdParam()
-                        return@LaunchedEffect
-                    }
-
-                    // レポートを年月でグループ化し、ソート
-                    val grouped = groupReports(reportsState)
-
-                    // 該当のreportIdのインデックスを探す
-                    // LazyColumnの構造: Menu(0) + HintBanner(1) + グループヘッダー + レポートアイテム
-                    var targetIndex = -1
-                    var currentIndex = 2 // Menu と HintBanner の2アイテム分をオフセット
-                    loop@ for ((_, monthReports) in grouped) {
-                        // currentIndex はヘッダーの位置（スキップ）
-                        for (report in monthReports) {
-                            currentIndex++ // レポートの位置へ移動してから確認
-                            if (report.id == id) {
-                                targetIndex = currentIndex
-                                break@loop
-                            }
                         }
-                        currentIndex++ // 次のグループのヘッダー位置へ移動
-                    }
 
-                    // 見つかった場合、スクロール
-                    if (targetIndex >= 0) {
-                        // 少し遅延を入れてレイアウトが完了してからスクロール
-                        delay(300)
-                        listState.animateScrollToItem(targetIndex)
-                    }
+                        // reportIdが指定されている場合、該当アイテムまで自動スクロール
+                        // キーを reportId のみにして、レポートが1件ずつ追加されるたびに
+                        // LaunchedEffect が再起動・キャンセルされる問題を防ぐ
+                        LaunchedEffect(reportId) {
+                            val id = reportId ?: return@LaunchedEffect
 
-                    clearReportIdParam()
+                            // 全件読み込み完了を待つ（reportsStateが変化しなくなるまで）
+                            var lastSize = -1
+                            while (reportsState.size != lastSize) {
+                                lastSize = reportsState.size
+                                delay(100)
+                            }
+                            if (reportsState.isEmpty()) {
+                                clearReportIdParam()
+                                return@LaunchedEffect
+                            }
+
+                            // レポートを年月でグループ化し、ソート
+                            val grouped = groupReports(reportsState)
+
+                            // 該当のreportIdのインデックスを探す
+                            // LazyColumnの構造: Menu(0) + HintBanner(1) + グループヘッダー + レポートアイテム
+                            var targetIndex = -1
+                            var currentIndex = 2 // Menu と HintBanner の2アイテム分をオフセット
+                            loop@ for ((_, monthReports) in grouped) {
+                                // currentIndex はヘッダーの位置（スキップ）
+                                for (report in monthReports) {
+                                    currentIndex++ // レポートの位置へ移動してから確認
+                                    if (report.id == id) {
+                                        targetIndex = currentIndex
+                                        break@loop
+                                    }
+                                }
+                                currentIndex++ // 次のグループのヘッダー位置へ移動
+                            }
+
+                            // 見つかった場合、スクロール
+                            if (targetIndex >= 0) {
+                                // 少し遅延を入れてレイアウトが完了してからスクロール
+                                delay(300)
+                                listState.animateScrollToItem(targetIndex)
+                            }
+
+                            clearReportIdParam()
+                        }
+
+                        // 画像ダイアログ
+                        selectedImagePath?.let { path ->
+                            ReportImageDialog(
+                                model = path,
+                                onDismiss = { selectedImagePath = null }
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = stringResource(Res.string.history_no_data),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
                 }
-
-                // 画像ダイアログ
-                selectedImagePath?.let { path ->
-                    ReportImageDialog(
-                        model = path,
-                        onDismiss = { selectedImagePath = null }
+                if (!showSelectShopDialog) {
+                    AddFab(
+                        modifier = Modifier.align(Alignment.BottomEnd),
+                        contentDescription = "食レポを追加",
+                        onAddClick = { showSelectShopDialog = true }
                     )
                 }
-            } else {
-                Text(
-                    text = stringResource(Res.string.history_no_data),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.secondary
-                )
             }
-        }
-        if (!showSelectShopDialog) {
-            AddFab(
-                modifier = Modifier.align(Alignment.BottomEnd),
-                contentDescription = "食レポを追加",
-                onAddClick = { showSelectShopDialog = true }
-            )
         }
         if (showSelectShopDialog) {
             SelectShopDialog(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -38,6 +38,7 @@ import dev.seabat.ramennote.domain.util.createTodayLocalDate
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.banner.HintBanner
 import dev.seabat.ramennote.ui.components.button.AddFab
+import dev.seabat.ramennote.ui.components.dialog.SelectShopDialog
 import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
 import dev.seabat.ramennote.ui.screens.componens.ReportCard
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
@@ -56,6 +57,7 @@ import ramennote.composeapp.generated.resources.history_year_all
 import ramennote.composeapp.generated.resources.note_hit_count
 import ramennote.composeapp.generated.resources.note_notification
 import ramennote.composeapp.generated.resources.screen_history_title
+import ramennote.composeapp.generated.resources.select_shop_dialog_write_report_button
 
 @Composable
 fun HistoryScreen(
@@ -234,7 +236,8 @@ fun HistoryScreen(
         if (showSelectShopDialog) {
             SelectShopDialog(
                 onDismiss = { showSelectShopDialog = false },
-                onReportClick = { shop ->
+                confirmButtonLabel = stringResource(Res.string.select_shop_dialog_write_report_button),
+                onConfirmClick = { shop ->
                     showSelectShopDialog = false
                     goToReport(shop.id, shop.name, shop.menuName1, createTodayLocalDate().toString())
                 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -260,8 +260,8 @@ private fun YearDropdownField(
     ) {
         DropdownAnchorField(
             text = if (selectedYear.isNotEmpty()) selectedYear else yearHint,
-            label = yearHint,
             expanded = expanded,
+            onToggle = { expanded = !expanded },
             modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
         )
         ExposedDropdownMenu(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -260,8 +260,8 @@ private fun YearDropdownField(
     ) {
         DropdownAnchorField(
             text = if (selectedYear.isNotEmpty()) selectedYear else yearHint,
+            label = yearHint,
             expanded = expanded,
-            onToggle = { expanded = !expanded },
             modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
         )
         ExposedDropdownMenu(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.util.createTodayLocalDate
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.banner.HintBanner
+import dev.seabat.ramennote.ui.components.button.AddFab
 import dev.seabat.ramennote.ui.screens.componens.DropdownAnchorField
 import dev.seabat.ramennote.ui.screens.componens.ReportCard
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
@@ -61,6 +63,7 @@ fun HistoryScreen(
     shopId: Int? = null,
     areaId: Int? = null,
     goToEditReport: (reportId: Int) -> Unit = {},
+    goToReport: (shopId: Int, shopName: String, menuName: String, iso8601Date: String) -> Unit = { _, _, _, _ -> },
     clearReportIdParam: () -> Unit = {},
     clearShopParam: () -> Unit = {},
     clearAreaParam: () -> Unit = {},
@@ -76,6 +79,7 @@ fun HistoryScreen(
 
     val listState = rememberLazyListState()
     var selectedImagePath by remember { mutableStateOf<String?>(null) }
+    var showSelectShopDialog by remember { mutableStateOf(false) }
     val xShareLauncher = createRememberedXShareLauncher()
     // ReportList 再生成時に渡す初期値（店舗フィルター適用後も検索テキストを保持するため）
     var listSearchText by remember { mutableStateOf(initialSearchText) }
@@ -95,127 +99,142 @@ fun HistoryScreen(
         }
     }
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(vertical = 8.dp, horizontal = 16.dp)
-    ) {
-        AppBar(
-            title =
-                when {
-                    areaNameState.isNotEmpty() ->
-                        "${stringResource(Res.string.screen_history_title)}($areaNameState)"
-                    shopNameState.isNotEmpty() ->
-                        "${stringResource(Res.string.screen_history_title)}($shopNameState)"
-                    yearState.isNotEmpty() ->
-                        "${stringResource(Res.string.screen_history_title)}($yearState)"
-                    else -> stringResource(Res.string.screen_history_title)
-                }
-        )
-        if (reportsState.isNotEmpty()) {
-            Box {
-                // レポート一覧
-                ReportList(
-                    reports = reportsState,
-                    listState = listState,
-                    searchText = listSearchText,
-                    isSearchResultVisible = listIsSearchResultVisible,
-                    shops = shops,
-                    years = yearsState,
-                    selectedYear = yearState,
-                    goToEditReport = goToEditReport,
-                    onDisplayImage = { imagePath -> selectedImagePath = imagePath },
-                    onFilter = { shop ->
-                        // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
-                        listSearchText = shop.name
-                        listIsSearchResultVisible = false
-                        viewModel.loadReportsByShop(shop.id)
-                    },
-                    onShare = { postText, photoName ->
-                        viewModel.shareToX(
-                            postText = postText,
-                            photoName = photoName,
-                            xShareLauncher = xShareLauncher
-                        )
-                    },
-                    onSearchTextChange = { text ->
-                        listSearchText = text
-                        if (text.isNotEmpty()) {
-                            listIsSearchResultVisible = true
-                            viewModel.searchShops(text)
-                        } else {
-                            listIsSearchResultVisible = false
-                            viewModel.loadReports()
-                        }
-                    },
-                    onYearSelect = { year ->
-                        listSearchText = ""
-                        listIsSearchResultVisible = false
-                        viewModel.loadReportsByYear(year)
-                    },
-                    onClearYearFilter = { viewModel.loadReports() }
-                )
-            }
-
-            // reportIdが指定されている場合、該当アイテムまで自動スクロール
-            // キーを reportId のみにして、レポートが1件ずつ追加されるたびに
-            // LaunchedEffect が再起動・キャンセルされる問題を防ぐ
-            LaunchedEffect(reportId) {
-                val id = reportId ?: return@LaunchedEffect
-
-                // 全件読み込み完了を待つ（reportsStateが変化しなくなるまで）
-                var lastSize = -1
-                while (reportsState.size != lastSize) {
-                    lastSize = reportsState.size
-                    delay(100)
-                }
-                if (reportsState.isEmpty()) {
-                    clearReportIdParam()
-                    return@LaunchedEffect
-                }
-
-                // レポートを年月でグループ化し、ソート
-                val grouped = groupReports(reportsState)
-
-                // 該当のreportIdのインデックスを探す
-                // LazyColumnの構造: Menu(0) + HintBanner(1) + グループヘッダー + レポートアイテム
-                var targetIndex = -1
-                var currentIndex = 2 // Menu と HintBanner の2アイテム分をオフセット
-                loop@ for ((_, monthReports) in grouped) {
-                    // currentIndex はヘッダーの位置（スキップ）
-                    for (report in monthReports) {
-                        currentIndex++ // レポートの位置へ移動してから確認
-                        if (report.id == id) {
-                            targetIndex = currentIndex
-                            break@loop
-                        }
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(vertical = 8.dp, horizontal = 16.dp)
+        ) {
+            AppBar(
+                title =
+                    when {
+                        areaNameState.isNotEmpty() ->
+                            "${stringResource(Res.string.screen_history_title)}($areaNameState)"
+                        shopNameState.isNotEmpty() ->
+                            "${stringResource(Res.string.screen_history_title)}($shopNameState)"
+                        yearState.isNotEmpty() ->
+                            "${stringResource(Res.string.screen_history_title)}($yearState)"
+                        else -> stringResource(Res.string.screen_history_title)
                     }
-                    currentIndex++ // 次のグループのヘッダー位置へ移動
+            )
+            if (reportsState.isNotEmpty()) {
+                Box {
+                    // レポート一覧
+                    ReportList(
+                        reports = reportsState,
+                        listState = listState,
+                        searchText = listSearchText,
+                        isSearchResultVisible = listIsSearchResultVisible,
+                        shops = shops,
+                        years = yearsState,
+                        selectedYear = yearState,
+                        goToEditReport = goToEditReport,
+                        onDisplayImage = { imagePath -> selectedImagePath = imagePath },
+                        onFilter = { shop ->
+                            // フィルター適用後も検索フィールドに店舗名を表示し、検索結果は非表示にする
+                            listSearchText = shop.name
+                            listIsSearchResultVisible = false
+                            viewModel.loadReportsByShop(shop.id)
+                        },
+                        onShare = { postText, photoName ->
+                            viewModel.shareToX(
+                                postText = postText,
+                                photoName = photoName,
+                                xShareLauncher = xShareLauncher
+                            )
+                        },
+                        onSearchTextChange = { text ->
+                            listSearchText = text
+                            if (text.isNotEmpty()) {
+                                listIsSearchResultVisible = true
+                                viewModel.searchShops(text)
+                            } else {
+                                listIsSearchResultVisible = false
+                                viewModel.loadReports()
+                            }
+                        },
+                        onYearSelect = { year ->
+                            listSearchText = ""
+                            listIsSearchResultVisible = false
+                            viewModel.loadReportsByYear(year)
+                        },
+                        onClearYearFilter = { viewModel.loadReports() }
+                    )
                 }
 
-                // 見つかった場合、スクロール
-                if (targetIndex >= 0) {
-                    // 少し遅延を入れてレイアウトが完了してからスクロール
-                    delay(300)
-                    listState.animateScrollToItem(targetIndex)
+                // reportIdが指定されている場合、該当アイテムまで自動スクロール
+                // キーを reportId のみにして、レポートが1件ずつ追加されるたびに
+                // LaunchedEffect が再起動・キャンセルされる問題を防ぐ
+                LaunchedEffect(reportId) {
+                    val id = reportId ?: return@LaunchedEffect
+
+                    // 全件読み込み完了を待つ（reportsStateが変化しなくなるまで）
+                    var lastSize = -1
+                    while (reportsState.size != lastSize) {
+                        lastSize = reportsState.size
+                        delay(100)
+                    }
+                    if (reportsState.isEmpty()) {
+                        clearReportIdParam()
+                        return@LaunchedEffect
+                    }
+
+                    // レポートを年月でグループ化し、ソート
+                    val grouped = groupReports(reportsState)
+
+                    // 該当のreportIdのインデックスを探す
+                    // LazyColumnの構造: Menu(0) + HintBanner(1) + グループヘッダー + レポートアイテム
+                    var targetIndex = -1
+                    var currentIndex = 2 // Menu と HintBanner の2アイテム分をオフセット
+                    loop@ for ((_, monthReports) in grouped) {
+                        // currentIndex はヘッダーの位置（スキップ）
+                        for (report in monthReports) {
+                            currentIndex++ // レポートの位置へ移動してから確認
+                            if (report.id == id) {
+                                targetIndex = currentIndex
+                                break@loop
+                            }
+                        }
+                        currentIndex++ // 次のグループのヘッダー位置へ移動
+                    }
+
+                    // 見つかった場合、スクロール
+                    if (targetIndex >= 0) {
+                        // 少し遅延を入れてレイアウトが完了してからスクロール
+                        delay(300)
+                        listState.animateScrollToItem(targetIndex)
+                    }
+
+                    clearReportIdParam()
                 }
 
-                clearReportIdParam()
-            }
-
-            // 画像ダイアログ
-            selectedImagePath?.let { path ->
-                ReportImageDialog(
-                    model = path,
-                    onDismiss = { selectedImagePath = null }
+                // 画像ダイアログ
+                selectedImagePath?.let { path ->
+                    ReportImageDialog(
+                        model = path,
+                        onDismiss = { selectedImagePath = null }
+                    )
+                }
+            } else {
+                Text(
+                    text = stringResource(Res.string.history_no_data),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.secondary
                 )
             }
-        } else {
-            Text(
-                text = stringResource(Res.string.history_no_data),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.secondary
+        }
+        AddFab(
+            modifier = Modifier.align(Alignment.BottomEnd),
+            onAddClick = { showSelectShopDialog = true }
+        )
+        if (showSelectShopDialog) {
+            SelectShopDialog(
+                onDismiss = { showSelectShopDialog = false },
+                onReportClick = { shop ->
+                    showSelectShopDialog = false
+                    goToReport(shop.id, shop.name, shop.menuName1, createTodayLocalDate().toString())
+                }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -38,7 +38,7 @@ import dev.seabat.ramennote.domain.util.createTodayLocalDate
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.banner.HintBanner
 import dev.seabat.ramennote.ui.components.button.AddFab
-import dev.seabat.ramennote.ui.screens.componens.DropdownAnchorField
+import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
 import dev.seabat.ramennote.ui.screens.componens.ReportCard
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
 import dev.seabat.ramennote.ui.screens.note.shop.SearchInputField
@@ -224,10 +224,13 @@ fun HistoryScreen(
                 )
             }
         }
-        AddFab(
-            modifier = Modifier.align(Alignment.BottomEnd),
-            onAddClick = { showSelectShopDialog = true }
-        )
+        if (!showSelectShopDialog) {
+            AddFab(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                contentDescription = "食レポを追加",
+                onAddClick = { showSelectShopDialog = true }
+            )
+        }
         if (showSelectShopDialog) {
             SelectShopDialog(
                 onDismiss = { showSelectShopDialog = false },

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockSelectShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/MockSelectShopViewModel.kt
@@ -1,0 +1,53 @@
+package dev.seabat.ramennote.ui.screens.history
+
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.Shop
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.datetime.LocalDate
+
+class MockSelectShopViewModel : SelectShopViewModelContract {
+    private val _areas = MutableStateFlow<List<Area>>(emptyList())
+    override val areas: StateFlow<List<Area>> = _areas.asStateFlow()
+
+    private val _shopsInArea = MutableStateFlow<List<Shop>>(emptyList())
+    override val shopsInArea: StateFlow<List<Shop>> = _shopsInArea.asStateFlow()
+
+    override fun loadAreas() {
+        // Preview用なので何もしない
+    }
+
+    override fun loadShopsByArea(areaName: String) {
+        // Preview用なので何もしない
+    }
+}
+
+/** エリアと店舗が選択できる状態のプレビュー用モック */
+class MockSelectShopViewModelWithData : SelectShopViewModelContract {
+    private val _areas =
+        MutableStateFlow(
+            listOf(
+                Area(areaId = 1, name = "渋谷", updatedDate = LocalDate.parse("2025-01-01"), count = 3, sort = 1),
+                Area(areaId = 2, name = "新宿", updatedDate = LocalDate.parse("2025-01-01"), count = 2, sort = 2)
+            )
+        )
+    override val areas: StateFlow<List<Area>> = _areas.asStateFlow()
+
+    private val _shopsInArea =
+        MutableStateFlow(
+            listOf(
+                Shop(id = 1, name = "一風堂 渋谷店", areaId = 1),
+                Shop(id = 2, name = "麺屋武蔵", areaId = 1)
+            )
+        )
+    override val shopsInArea: StateFlow<List<Shop>> = _shopsInArea.asStateFlow()
+
+    override fun loadAreas() {
+        // Preview用なので何もしない
+    }
+
+    override fun loadShopsByArea(areaName: String) {
+        // Preview用なので何もしない
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.Shop
@@ -64,12 +63,7 @@ fun SelectShopDialog(
             )
 
             // エリアドロップダウン
-            Text(
-                text = "エリア",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(4.dp))
+            // label を DropdownAnchorField 内に持つため外側ラベルは不要
             ExposedDropdownMenuBox(
                 expanded = areaExpanded,
                 onExpandedChange = { areaExpanded = !areaExpanded },
@@ -77,8 +71,8 @@ fun SelectShopDialog(
             ) {
                 DropdownAnchorField(
                     text = selectedArea?.name ?: "",
+                    label = "エリア",
                     expanded = areaExpanded,
-                    onToggle = { areaExpanded = !areaExpanded },
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -104,27 +98,18 @@ fun SelectShopDialog(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 店舗ドロップダウン（エリア未選択時はグレーアウト）
+            // 店舗ドロップダウン（エリア未選択時は enabled = false で MD3 の disabled スタイルを自動適用）
             val shopEnabled = selectedArea != null
-            Text(
-                text = "店舗",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.alpha(if (shopEnabled) 1f else 0.38f)
-            )
-            Spacer(modifier = Modifier.height(4.dp))
             ExposedDropdownMenuBox(
                 expanded = shopExpanded,
                 onExpandedChange = { if (shopEnabled) shopExpanded = !shopExpanded },
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .alpha(if (shopEnabled) 1f else 0.38f)
+                modifier = Modifier.fillMaxWidth()
             ) {
                 DropdownAnchorField(
                     text = selectedShop?.name ?: "",
+                    label = "店舗",
                     expanded = shopExpanded,
-                    onToggle = { if (shopEnabled) shopExpanded = !shopExpanded },
+                    enabled = shopEnabled,
                     modifier =
                         Modifier
                             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
@@ -1,0 +1,195 @@
+package dev.seabat.ramennote.ui.screens.history
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.ui.components.dialog.WideDialog
+import dev.seabat.ramennote.ui.screens.componens.DropdownAnchorField
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectShopDialog(
+    onDismiss: () -> Unit,
+    onReportClick: (Shop) -> Unit,
+    viewModel: SelectShopViewModelContract = koinViewModel<SelectShopViewModel>()
+) {
+    val areas by viewModel.areas.collectAsState()
+    val shopsInArea by viewModel.shopsInArea.collectAsState()
+
+    var selectedArea by remember { mutableStateOf<Area?>(null) }
+    var selectedShop by remember { mutableStateOf<Shop?>(null) }
+    var areaExpanded by remember { mutableStateOf(false) }
+    var shopExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { viewModel.loadAreas() }
+
+    WideDialog(onDismiss = onDismiss) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+        ) {
+            Text(
+                text = "店舗を選択",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // エリアドロップダウン
+            Text(
+                text = "エリア",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            ExposedDropdownMenuBox(
+                expanded = areaExpanded,
+                onExpandedChange = { areaExpanded = !areaExpanded },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                DropdownAnchorField(
+                    text = selectedArea?.name ?: "",
+                    expanded = areaExpanded,
+                    onToggle = { areaExpanded = !areaExpanded },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                )
+                ExposedDropdownMenu(
+                    expanded = areaExpanded,
+                    onDismissRequest = { areaExpanded = false }
+                ) {
+                    areas.forEach { area ->
+                        DropdownMenuItem(
+                            text = { Text(area.name) },
+                            onClick = {
+                                selectedArea = area
+                                selectedShop = null
+                                viewModel.loadShopsByArea(area.name)
+                                areaExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 店舗ドロップダウン（エリア未選択時はグレーアウト）
+            val shopEnabled = selectedArea != null
+            Text(
+                text = "店舗",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.alpha(if (shopEnabled) 1f else 0.38f)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            ExposedDropdownMenuBox(
+                expanded = shopExpanded,
+                onExpandedChange = { if (shopEnabled) shopExpanded = !shopExpanded },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .alpha(if (shopEnabled) 1f else 0.38f)
+            ) {
+                DropdownAnchorField(
+                    text = selectedShop?.name ?: "",
+                    expanded = shopExpanded,
+                    onToggle = { if (shopEnabled) shopExpanded = !shopExpanded },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = shopEnabled)
+                )
+                ExposedDropdownMenu(
+                    expanded = shopExpanded,
+                    onDismissRequest = { shopExpanded = false }
+                ) {
+                    shopsInArea.forEach { shop ->
+                        DropdownMenuItem(
+                            text = { Text(shop.name) },
+                            onClick = {
+                                selectedShop = shop
+                                shopExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ボタン行
+            Row(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                OutlinedButton(onClick = onDismiss) {
+                    Text("キャンセル")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { selectedShop?.let { onReportClick(it) } },
+                    enabled = selectedShop != null
+                ) {
+                    Text("レポートを書く")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SelectShopDialogPreview() {
+    RamenNoteTheme {
+        SelectShopDialog(
+            onDismiss = {},
+            onReportClick = {},
+            viewModel = MockSelectShopViewModel()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SelectShopDialogWithDataPreview() {
+    RamenNoteTheme {
+        SelectShopDialog(
+            onDismiss = {},
+            onReportClick = {},
+            viewModel = MockSelectShopViewModelWithData()
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.Shop
@@ -63,7 +64,12 @@ fun SelectShopDialog(
             )
 
             // エリアドロップダウン
-            // label を DropdownAnchorField 内に持つため外側ラベルは不要
+            Text(
+                text = "エリア",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(4.dp))
             ExposedDropdownMenuBox(
                 expanded = areaExpanded,
                 onExpandedChange = { areaExpanded = !areaExpanded },
@@ -71,8 +77,8 @@ fun SelectShopDialog(
             ) {
                 DropdownAnchorField(
                     text = selectedArea?.name ?: "",
-                    label = "エリア",
                     expanded = areaExpanded,
+                    onToggle = { areaExpanded = !areaExpanded },
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -98,18 +104,27 @@ fun SelectShopDialog(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // 店舗ドロップダウン（エリア未選択時は enabled = false で MD3 の disabled スタイルを自動適用）
+            // 店舗ドロップダウン（エリア未選択時はグレーアウト）
             val shopEnabled = selectedArea != null
+            Text(
+                text = "店舗",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.alpha(if (shopEnabled) 1f else 0.38f)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
             ExposedDropdownMenuBox(
                 expanded = shopExpanded,
                 onExpandedChange = { if (shopEnabled) shopExpanded = !shopExpanded },
-                modifier = Modifier.fillMaxWidth()
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .alpha(if (shopEnabled) 1f else 0.38f)
             ) {
                 DropdownAnchorField(
                     text = selectedShop?.name ?: "",
-                    label = "店舗",
                     expanded = shopExpanded,
-                    enabled = shopEnabled,
+                    onToggle = { if (shopEnabled) shopExpanded = !shopExpanded },
                     modifier =
                         Modifier
                             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopDialog.kt
@@ -1,5 +1,6 @@
 package dev.seabat.ramennote.ui.screens.history
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,22 +14,23 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.seabat.ramennote.domain.model.Area
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.dialog.WideDialog
-import dev.seabat.ramennote.ui.screens.componens.DropdownAnchorField
+import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -40,8 +42,8 @@ fun SelectShopDialog(
     onReportClick: (Shop) -> Unit,
     viewModel: SelectShopViewModelContract = koinViewModel<SelectShopViewModel>()
 ) {
-    val areas by viewModel.areas.collectAsState()
-    val shopsInArea by viewModel.shopsInArea.collectAsState()
+    val areas by viewModel.areas.collectAsStateWithLifecycle()
+    val shopsInArea by viewModel.shopsInArea.collectAsStateWithLifecycle()
 
     var selectedArea by remember { mutableStateOf<Area?>(null) }
     var selectedShop by remember { mutableStateOf<Shop?>(null) }
@@ -59,45 +61,47 @@ fun SelectShopDialog(
         ) {
             Text(
                 text = "店舗を選択",
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
             // エリアドロップダウン
-            Text(
-                text = "エリア",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            ExposedDropdownMenuBox(
-                expanded = areaExpanded,
-                onExpandedChange = { areaExpanded = !areaExpanded },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                DropdownAnchorField(
-                    text = selectedArea?.name ?: "",
-                    expanded = areaExpanded,
-                    onToggle = { areaExpanded = !areaExpanded },
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+            Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {
+                Text(
+                    text = "エリア",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                ExposedDropdownMenu(
+                Spacer(modifier = Modifier.height(4.dp))
+                ExposedDropdownMenuBox(
                     expanded = areaExpanded,
-                    onDismissRequest = { areaExpanded = false }
+                    onExpandedChange = { areaExpanded = !areaExpanded },
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    areas.forEach { area ->
-                        DropdownMenuItem(
-                            text = { Text(area.name) },
-                            onClick = {
-                                selectedArea = area
-                                selectedShop = null
-                                viewModel.loadShopsByArea(area.name)
-                                areaExpanded = false
-                            }
-                        )
+                    DropdownAnchorField(
+                        text = selectedArea?.name ?: "",
+                        expanded = areaExpanded,
+                        onToggle = { areaExpanded = !areaExpanded },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = true)
+                    )
+                    ExposedDropdownMenu(
+                        expanded = areaExpanded,
+                        onDismissRequest = { areaExpanded = false }
+                    ) {
+                        areas.forEach { area ->
+                            DropdownMenuItem(
+                                text = { Text(area.name) },
+                                onClick = {
+                                    selectedArea = area
+                                    selectedShop = null
+                                    viewModel.loadShopsByArea(area.name)
+                                    areaExpanded = false
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -106,42 +110,45 @@ fun SelectShopDialog(
 
             // 店舗ドロップダウン（エリア未選択時はグレーアウト）
             val shopEnabled = selectedArea != null
-            Text(
-                text = "店舗",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.alpha(if (shopEnabled) 1f else 0.38f)
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            ExposedDropdownMenuBox(
-                expanded = shopExpanded,
-                onExpandedChange = { if (shopEnabled) shopExpanded = !shopExpanded },
+            Column(
                 modifier =
                     Modifier
-                        .fillMaxWidth()
+                        .semantics(mergeDescendants = true) {}
                         .alpha(if (shopEnabled) 1f else 0.38f)
             ) {
-                DropdownAnchorField(
-                    text = selectedShop?.name ?: "",
-                    expanded = shopExpanded,
-                    onToggle = { if (shopEnabled) shopExpanded = !shopExpanded },
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = shopEnabled)
+                Text(
+                    text = "店舗",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                ExposedDropdownMenu(
+                Spacer(modifier = Modifier.height(4.dp))
+                ExposedDropdownMenuBox(
                     expanded = shopExpanded,
-                    onDismissRequest = { shopExpanded = false }
+                    onExpandedChange = { if (shopEnabled) shopExpanded = !shopExpanded },
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    shopsInArea.forEach { shop ->
-                        DropdownMenuItem(
-                            text = { Text(shop.name) },
-                            onClick = {
-                                selectedShop = shop
-                                shopExpanded = false
-                            }
-                        )
+                    DropdownAnchorField(
+                        text = selectedShop?.name ?: "",
+                        expanded = shopExpanded,
+                        onToggle = { if (shopEnabled) shopExpanded = !shopExpanded },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = shopEnabled)
+                    )
+                    ExposedDropdownMenu(
+                        expanded = shopExpanded,
+                        onDismissRequest = { shopExpanded = false }
+                    ) {
+                        shopsInArea.forEach { shop ->
+                            DropdownMenuItem(
+                                text = { Text(shop.name) },
+                                onClick = {
+                                    selectedShop = shop
+                                    shopExpanded = false
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -150,10 +157,10 @@ fun SelectShopDialog(
 
             // ボタン行
             Row(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
             ) {
-                Spacer(modifier = Modifier.weight(1f))
-                OutlinedButton(onClick = onDismiss) {
+                TextButton(onClick = onDismiss) {
                     Text("キャンセル")
                 }
                 Spacer(modifier = Modifier.width(8.dp))

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopViewModel.kt
@@ -1,0 +1,36 @@
+package dev.seabat.ramennote.ui.screens.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCaseContract
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class SelectShopViewModel(
+    private val loadAreasUseCase: LoadAreasUseCaseContract,
+    private val loadShopListByAreaUseCase: LoadShopListByAreaUseCaseContract
+) : ViewModel(),
+    SelectShopViewModelContract {
+    private val _areas = MutableStateFlow<List<Area>>(emptyList())
+    override val areas: StateFlow<List<Area>> = _areas.asStateFlow()
+
+    private val _shopsInArea = MutableStateFlow<List<Shop>>(emptyList())
+    override val shopsInArea: StateFlow<List<Shop>> = _shopsInArea.asStateFlow()
+
+    override fun loadAreas() {
+        viewModelScope.launch {
+            _areas.value = loadAreasUseCase()
+        }
+    }
+
+    override fun loadShopsByArea(areaName: String) {
+        viewModelScope.launch {
+            _shopsInArea.value = loadShopListByAreaUseCase(areaName)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/SelectShopViewModelContract.kt
@@ -1,0 +1,14 @@
+package dev.seabat.ramennote.ui.screens.history
+
+import dev.seabat.ramennote.domain.model.Area
+import dev.seabat.ramennote.domain.model.Shop
+import kotlinx.coroutines.flow.StateFlow
+
+interface SelectShopViewModelContract {
+    val areas: StateFlow<List<Area>>
+    val shopsInArea: StateFlow<List<Shop>>
+
+    fun loadAreas()
+
+    fun loadShopsByArea(areaName: String)
+}

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeViewModel.kt
@@ -9,8 +9,8 @@ import dev.seabat.ramennote.domain.model.Schedule
 import dev.seabat.ramennote.domain.usecase.LoadFavoriteShopsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImagePathUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadImageUseCaseContract
-import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadRecentFullReportsUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadRecentScheduleUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadYearlyReportStatsUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateScheduleInShopUseCaseContract
 import dev.seabat.ramennote.ui.gallery.SharedImage

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -49,7 +49,7 @@ class EditAreaViewModel(
     override fun deleteArea(areaId: Int) {
         viewModelScope.launch {
             _deleteState.value = RunStatus.Loading()
-            _editState.value = deleteAreaUseCase(areaId)
+            _deleteState.value = deleteAreaUseCase(areaId)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/MockScheduleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/MockScheduleViewModel.kt
@@ -40,6 +40,10 @@ class MockScheduleViewModel : ScheduleViewModelContract {
         // Preview / Mock 用: すでに初期値を流しているため何もしない
     }
 
+    override fun addSchedule(shopId: Int, date: LocalDate) {
+        // Preview / Mock 用
+    }
+
     override fun editSchedule(shopId: Int, date: LocalDate) {
         // Preview / Mock 用
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -95,23 +95,23 @@ fun ScheduleScreen(
         viewModel.loadSchedule()
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Column(
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize(),
+        verticalArrangement = Arrangement.Top
+    ) {
+        AppBar(
+            title = stringResource(Res.string.screen_schedule_title)
+        )
+
+        Box(
             modifier =
                 Modifier
-                    .fillMaxSize(),
-            verticalArrangement = Arrangement.Top
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp)
         ) {
-            AppBar(
-                title = stringResource(Res.string.screen_schedule_title)
-            )
-
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp)
-            ) {
+            Column(modifier = Modifier.fillMaxSize()) {
                 if (schedules.isNotEmpty()) {
                     ScheduleList(
                         schedules = schedules,
@@ -141,17 +141,16 @@ fun ScheduleScreen(
                     )
                 }
             }
-        }
 
-        // FAB（他のダイアログが開いていない時のみ表示）
-        if (dialogState == DialogState.Hidden) {
-            AddFab(
-                modifier = Modifier.align(Alignment.BottomEnd),
-                contentDescription = "予定を追加",
-                onAddClick = { dialogState = DialogState.SelectShop }
-            )
+            // FAB（他のダイアログが開いていない時のみ表示）
+            if (dialogState == DialogState.Hidden) {
+                AddFab(
+                    modifier = Modifier.align(Alignment.BottomEnd),
+                    contentDescription = "予定を追加",
+                    onAddClick = { dialogState = DialogState.SelectShop }
+                )
+            }
         }
-
     }
 
     ScheduleScreenDialog(

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -189,7 +189,7 @@ private fun ScheduleScreenDialog(
                             datePickerOnClickHandler(
                                 addDatePickerState,
                                 showErrorDialog = onShowPastDate,
-                                clearClicked = {},
+
                                 dismissDatePicker = onDismiss,
                                 editSchedule = { date -> onAddSchedule(state.shop.id, date) }
                             )
@@ -219,7 +219,7 @@ private fun ScheduleScreenDialog(
                             datePickerOnClickHandler(
                                 editDatePickerState,
                                 showErrorDialog = onShowPastDate,
-                                clearClicked = {},
+
                                 dismissDatePicker = onDismiss,
                                 editSchedule = { date -> onEditSchedule(state.shopId, date) }
                             )
@@ -413,32 +413,42 @@ private fun ScheduleRow(
     }
 }
 
+/**
+ * DatePickerDialog の OK ボタン押下時の処理。
+ *
+ * 選択された日付が今日以降であれば [editSchedule] を呼び出して [dismissDatePicker] でダイアログを閉じる。
+ * 過去の日付が選択された場合は [showErrorDialog] を呼び出し、ダイアログは閉じない。
+ * 日付が未選択の場合は [dismissDatePicker] のみ呼び出す。
+ *
+ * @param datePickerState DatePicker の状態。選択日付ミリ秒を取得するために使用する
+ * @param showErrorDialog 過去日付が選択されたときに呼び出すコールバック
+ * @param editSchedule 有効な日付が選択されたときに呼び出すコールバック。選択された [LocalDate] を受け取る
+ * @param dismissDatePicker DatePickerDialog を閉じるコールバック。過去日付エラー時は呼ばれない
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 private fun datePickerOnClickHandler(
     datePickerState: DatePickerState,
     showErrorDialog: () -> Unit,
-    clearClicked: () -> Unit,
     editSchedule: (LocalDate) -> Unit = { _ -> },
     dismissDatePicker: () -> Unit
 ) {
-    try {
-        val millis = datePickerState.selectedDateMillis
-        if (millis != null) {
-            val date =
-                Instant
-                    .fromEpochMilliseconds(millis)
-                    .toLocalDateTime(TimeZone.currentSystemDefault())
-                    .date
+    val millis = datePickerState.selectedDateMillis
+    if (millis != null) {
+        val date =
+            Instant
+                .fromEpochMilliseconds(millis)
+                .toLocalDateTime(TimeZone.currentSystemDefault())
+                .date
 
-            // 今日を含めた未来日かどうかをチェック
-            if (!date.isTodayOrFuture()) {
-                showErrorDialog()
-            } else {
-                editSchedule(date)
-            }
+        // 今日を含めた未来日かどうかをチェック
+        if (!date.isTodayOrFuture()) {
+            // エラーダイアログを表示するため dismissDatePicker は呼ばない
+            showErrorDialog()
+        } else {
+            editSchedule(date)
+            dismissDatePicker()
         }
-    } finally {
-        clearClicked()
+    } else {
         dismissDatePicker()
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -2,6 +2,7 @@ package dev.seabat.ramennote.ui.screens.schedule
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -22,7 +23,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,11 +31,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.seabat.ramennote.domain.extension.isTodayOrFuture
 import dev.seabat.ramennote.domain.model.Schedule
+import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.alert.AppAlert
 import dev.seabat.ramennote.ui.components.alert.AppTwoButtonAlert
+import dev.seabat.ramennote.ui.components.button.AddFab
+import dev.seabat.ramennote.ui.components.dialog.SelectShopDialog
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import dev.seabat.ramennote.ui.util.dayOfWeekJp
 import kotlinx.datetime.Instant
@@ -55,6 +59,7 @@ import ramennote.composeapp.generated.resources.schedule_delete_confirm
 import ramennote.composeapp.generated.resources.schedule_no_data
 import ramennote.composeapp.generated.resources.schedule_picker_label
 import ramennote.composeapp.generated.resources.screen_schedule_title
+import ramennote.composeapp.generated.resources.select_shop_dialog_create_schedule_button
 
 private sealed interface ErrorDialogType {
     object Hidden : ErrorDialogType
@@ -66,6 +71,16 @@ private sealed interface ErrorDialogType {
     ) : ErrorDialogType
 }
 
+private sealed interface AddScheduleDialogState {
+    object Hidden : AddScheduleDialogState
+
+    object SelectShop : AddScheduleDialogState
+
+    data class DatePicker(
+        val shop: Shop
+    ) : AddScheduleDialogState
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ScheduleScreen(
@@ -73,63 +88,122 @@ fun ScheduleScreen(
     goToShop: (shopId: Int, shopName: String) -> Unit = { _, _ -> },
     viewModel: ScheduleViewModelContract = koinViewModel<ScheduleViewModel>()
 ) {
-    val schedules by viewModel.schedules.collectAsState()
+    val schedules by viewModel.schedules.collectAsStateWithLifecycle()
     var showDatePicker by remember { mutableStateOf(false) }
     var clickedShopId by remember { mutableStateOf(0) }
     var errorDialogType by remember { mutableStateOf<ErrorDialogType>(ErrorDialogType.Hidden) }
     val datePickerState = rememberDatePickerState()
+    var addDialogState by remember { mutableStateOf<AddScheduleDialogState>(AddScheduleDialogState.Hidden) }
+    val addDatePickerState = rememberDatePickerState()
 
     LaunchedEffect(Unit) {
         viewModel.loadSchedule()
     }
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize(),
-        verticalArrangement = Arrangement.Top
-    ) {
-        AppBar(
-            title = stringResource(Res.string.screen_schedule_title)
-        )
-
+    Box(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp)
+                    .fillMaxSize(),
+            verticalArrangement = Arrangement.Top
         ) {
-            if (schedules.isNotEmpty()) {
-                ScheduleList(
-                    schedules = schedules,
-                    onReportClick = { schedule ->
-                        goToReport(
-                            schedule.shopId,
-                            schedule.shopName,
-                            schedule.menuName,
-                            schedule.scheduledDate?.toString() ?: ""
+            AppBar(
+                title = stringResource(Res.string.screen_schedule_title)
+            )
+
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+            ) {
+                if (schedules.isNotEmpty()) {
+                    ScheduleList(
+                        schedules = schedules,
+                        onReportClick = { schedule ->
+                            goToReport(
+                                schedule.shopId,
+                                schedule.shopName,
+                                schedule.menuName,
+                                schedule.scheduledDate?.toString() ?: ""
+                            )
+                        },
+                        onEditClick = { shopId ->
+                            showDatePicker = true
+                            clickedShopId = shopId
+                        },
+                        onDeleteClick = { shopId ->
+                            errorDialogType = ErrorDialogType.DeleteConfirm(shopId)
+                        },
+                        onListItemClick = { schedule ->
+                            goToShop(schedule.shopId, schedule.shopName)
+                        }
+                    )
+                } else {
+                    Text(
+                        text = stringResource(Res.string.schedule_no_data),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+            }
+        }
+
+        // FAB（他のダイアログが開いていない時のみ表示）
+        if (addDialogState == AddScheduleDialogState.Hidden && !showDatePicker && errorDialogType == ErrorDialogType.Hidden) {
+            AddFab(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                contentDescription = "予定を追加",
+                onAddClick = { addDialogState = AddScheduleDialogState.SelectShop }
+            )
+        }
+
+        // 店舗選択ダイアログ（追加フロー）
+        if (addDialogState == AddScheduleDialogState.SelectShop) {
+            SelectShopDialog(
+                onDismiss = { addDialogState = AddScheduleDialogState.Hidden },
+                confirmButtonLabel = stringResource(Res.string.select_shop_dialog_create_schedule_button),
+                onConfirmClick = { shop ->
+                    addDialogState = AddScheduleDialogState.DatePicker(shop)
+                }
+            )
+        }
+    }
+
+    // 日付選択ダイアログ（追加フロー）
+    if (addDialogState is AddScheduleDialogState.DatePicker) {
+        val shop = (addDialogState as AddScheduleDialogState.DatePicker).shop
+        DatePickerDialog(
+            onDismissRequest = { addDialogState = AddScheduleDialogState.Hidden },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerOnClickHandler(
+                            addDatePickerState,
+                            showErrorDialog = { errorDialogType = ErrorDialogType.PastDate },
+                            clearClicked = {},
+                            dismissDatePicker = { addDialogState = AddScheduleDialogState.Hidden },
+                            editSchedule = { date -> viewModel.addSchedule(shop.id, date) }
                         )
-                    },
-                    onEditClick = { shopId ->
-                        showDatePicker = true
-                        clickedShopId = shopId
-                    },
-                    onDeleteClick = { shopId ->
-                        errorDialogType = ErrorDialogType.DeleteConfirm(shopId)
-                    },
-                    onListItemClick = { schedule ->
-                        goToShop(schedule.shopId, schedule.shopName)
                     }
-                )
-            } else {
+                ) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { addDialogState = AddScheduleDialogState.Hidden }) { Text("Cancel") }
+            }
+        ) {
+            Column {
                 Text(
-                    text = stringResource(Res.string.schedule_no_data),
+                    text = stringResource(Res.string.schedule_picker_label),
                     style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.secondary
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                 )
+                DatePicker(state = addDatePickerState)
             }
         }
     }
+
+    // 既存: 編集用日付選択ダイアログ
     if (showDatePicker) {
         DatePickerDialog(
             onDismissRequest = { showDatePicker = false },

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -61,24 +61,24 @@ import ramennote.composeapp.generated.resources.schedule_picker_label
 import ramennote.composeapp.generated.resources.screen_schedule_title
 import ramennote.composeapp.generated.resources.select_shop_dialog_create_schedule_button
 
-private sealed interface ErrorDialogType {
-    object Hidden : ErrorDialogType
+private sealed interface DialogState {
+    object Hidden : DialogState
 
-    object PastDate : ErrorDialogType
+    object SelectShop : DialogState
+
+    data class AddDatePicker(
+        val shop: Shop
+    ) : DialogState
+
+    data class EditDatePicker(
+        val shopId: Int
+    ) : DialogState
+
+    object PastDate : DialogState
 
     data class DeleteConfirm(
         val shopId: Int
-    ) : ErrorDialogType
-}
-
-private sealed interface AddScheduleDialogState {
-    object Hidden : AddScheduleDialogState
-
-    object SelectShop : AddScheduleDialogState
-
-    data class DatePicker(
-        val shop: Shop
-    ) : AddScheduleDialogState
+    ) : DialogState
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -89,12 +89,7 @@ fun ScheduleScreen(
     viewModel: ScheduleViewModelContract = koinViewModel<ScheduleViewModel>()
 ) {
     val schedules by viewModel.schedules.collectAsStateWithLifecycle()
-    var showDatePicker by remember { mutableStateOf(false) }
-    var clickedShopId by remember { mutableStateOf(0) }
-    var errorDialogType by remember { mutableStateOf<ErrorDialogType>(ErrorDialogType.Hidden) }
-    val datePickerState = rememberDatePickerState()
-    var addDialogState by remember { mutableStateOf<AddScheduleDialogState>(AddScheduleDialogState.Hidden) }
-    val addDatePickerState = rememberDatePickerState()
+    var dialogState by remember { mutableStateOf<DialogState>(DialogState.Hidden) }
 
     LaunchedEffect(Unit) {
         viewModel.loadSchedule()
@@ -129,11 +124,10 @@ fun ScheduleScreen(
                             )
                         },
                         onEditClick = { shopId ->
-                            showDatePicker = true
-                            clickedShopId = shopId
+                            dialogState = DialogState.EditDatePicker(shopId)
                         },
                         onDeleteClick = { shopId ->
-                            errorDialogType = ErrorDialogType.DeleteConfirm(shopId)
+                            dialogState = DialogState.DeleteConfirm(shopId)
                         },
                         onListItemClick = { schedule ->
                             goToShop(schedule.shopId, schedule.shopName)
@@ -150,111 +144,126 @@ fun ScheduleScreen(
         }
 
         // FAB（他のダイアログが開いていない時のみ表示）
-        if (addDialogState == AddScheduleDialogState.Hidden && !showDatePicker && errorDialogType == ErrorDialogType.Hidden) {
+        if (dialogState == DialogState.Hidden) {
             AddFab(
                 modifier = Modifier.align(Alignment.BottomEnd),
                 contentDescription = "予定を追加",
-                onAddClick = { addDialogState = AddScheduleDialogState.SelectShop }
+                onAddClick = { dialogState = DialogState.SelectShop }
             )
         }
 
-        // 店舗選択ダイアログ（追加フロー）
-        if (addDialogState == AddScheduleDialogState.SelectShop) {
-            SelectShopDialog(
-                onDismiss = { addDialogState = AddScheduleDialogState.Hidden },
-                confirmButtonLabel = stringResource(Res.string.select_shop_dialog_create_schedule_button),
-                onConfirmClick = { shop ->
-                    addDialogState = AddScheduleDialogState.DatePicker(shop)
+    }
+
+    ScheduleScreenDialog(
+        dialogState = dialogState,
+        onDismiss = { dialogState = DialogState.Hidden },
+        onSelectShop = { shop -> dialogState = DialogState.AddDatePicker(shop) },
+        onShowPastDate = { dialogState = DialogState.PastDate },
+        onAddSchedule = { shopId, date -> viewModel.addSchedule(shopId, date) },
+        onEditSchedule = { shopId, date -> viewModel.editSchedule(shopId, date) },
+        onDeleteSchedule = { shopId -> viewModel.deleteSchedule(shopId) }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScheduleScreenDialog(
+    dialogState: DialogState,
+    onDismiss: () -> Unit,
+    onSelectShop: (Shop) -> Unit,
+    onShowPastDate: () -> Unit,
+    onAddSchedule: (shopId: Int, date: LocalDate) -> Unit,
+    onEditSchedule: (shopId: Int, date: LocalDate) -> Unit,
+    onDeleteSchedule: (shopId: Int) -> Unit
+) {
+    val editDatePickerState = rememberDatePickerState()
+    val addDatePickerState = rememberDatePickerState()
+
+    when (val state = dialogState) {
+        is DialogState.AddDatePicker -> {
+            DatePickerDialog(
+                onDismissRequest = onDismiss,
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            datePickerOnClickHandler(
+                                addDatePickerState,
+                                showErrorDialog = onShowPastDate,
+                                clearClicked = {},
+                                dismissDatePicker = onDismiss,
+                                editSchedule = { date -> onAddSchedule(state.shop.id, date) }
+                            )
+                        }
+                    ) { Text("OK") }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
                 }
-            )
-        }
-    }
-
-    // 日付選択ダイアログ（追加フロー）
-    if (addDialogState is AddScheduleDialogState.DatePicker) {
-        val shop = (addDialogState as AddScheduleDialogState.DatePicker).shop
-        DatePickerDialog(
-            onDismissRequest = { addDialogState = AddScheduleDialogState.Hidden },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        datePickerOnClickHandler(
-                            addDatePickerState,
-                            showErrorDialog = { errorDialogType = ErrorDialogType.PastDate },
-                            clearClicked = {},
-                            dismissDatePicker = { addDialogState = AddScheduleDialogState.Hidden },
-                            editSchedule = { date -> viewModel.addSchedule(shop.id, date) }
-                        )
-                    }
-                ) { Text("OK") }
-            },
-            dismissButton = {
-                TextButton(onClick = { addDialogState = AddScheduleDialogState.Hidden }) { Text("Cancel") }
-            }
-        ) {
-            Column {
-                Text(
-                    text = stringResource(Res.string.schedule_picker_label),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-                DatePicker(state = addDatePickerState)
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(Res.string.schedule_picker_label),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                    DatePicker(state = addDatePickerState)
+                }
             }
         }
-    }
-
-    // 既存: 編集用日付選択ダイアログ
-    if (showDatePicker) {
-        DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        datePickerOnClickHandler(
-                            datePickerState,
-                            showErrorDialog = { errorDialogType = ErrorDialogType.PastDate },
-                            clearClicked = { clickedShopId = 0 },
-                            dismissDatePicker = { showDatePicker = false },
-                            editSchedule = { date -> viewModel.editSchedule(clickedShopId, date) }
-                        )
-                    }
-                ) { Text("OK") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
-            }
-        ) {
-            Column {
-                Text(
-                    text = stringResource(Res.string.schedule_picker_label),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-                DatePicker(state = datePickerState)
+        is DialogState.EditDatePicker -> {
+            DatePickerDialog(
+                onDismissRequest = onDismiss,
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            datePickerOnClickHandler(
+                                editDatePickerState,
+                                showErrorDialog = onShowPastDate,
+                                clearClicked = {},
+                                dismissDatePicker = onDismiss,
+                                editSchedule = { date -> onEditSchedule(state.shopId, date) }
+                            )
+                        }
+                    ) { Text("OK") }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                }
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(Res.string.schedule_picker_label),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                    DatePicker(state = editDatePickerState)
+                }
             }
         }
-    }
-    // エラーダイアログ
-    when (val shouldShow = errorDialogType) {
-        is ErrorDialogType.PastDate -> {
+        is DialogState.PastDate -> {
             AppAlert(
                 message = stringResource(Res.string.add_schedule_error_past_date_message),
-                onConfirm = { errorDialogType = ErrorDialogType.Hidden }
+                onConfirm = onDismiss
             )
         }
-        is ErrorDialogType.DeleteConfirm -> {
+        is DialogState.DeleteConfirm -> {
             AppTwoButtonAlert(
                 message = stringResource(Res.string.schedule_delete_confirm),
                 onConfirm = {
-                    viewModel.deleteSchedule(shouldShow.shopId)
-                    errorDialogType = ErrorDialogType.Hidden
+                    onDeleteSchedule(state.shopId)
+                    onDismiss()
                 },
-                onNegative = {
-                    errorDialogType = ErrorDialogType.Hidden
-                }
+                onNegative = onDismiss
             )
         }
-        is ErrorDialogType.Hidden -> {
+        is DialogState.SelectShop -> {
+            SelectShopDialog(
+                onDismiss = onDismiss,
+                confirmButtonLabel = stringResource(Res.string.select_shop_dialog_create_schedule_button),
+                onConfirmClick = { shop -> onSelectShop(shop) }
+            )
+        }
+        is DialogState.Hidden -> {
             // 何も表示しない
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleViewModel.kt
@@ -28,6 +28,15 @@ class ScheduleViewModel(
         }
     }
 
+    override fun addSchedule(shopId: Int, date: LocalDate) {
+        viewModelScope.launch {
+            updateScheduleInShopUseCaseContract(shopId, date)
+
+            val schedules = loadScheduledShopsUseCase()
+            _schedules.value = schedules
+        }
+    }
+
     override fun editSchedule(shopId: Int, date: LocalDate) {
         viewModelScope.launch {
             updateScheduleInShopUseCaseContract(shopId, date)

--- a/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleViewModelContract.kt
+++ b/composeApp/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleViewModelContract.kt
@@ -9,6 +9,8 @@ interface ScheduleViewModelContract {
 
     fun loadSchedule()
 
+    fun addSchedule(shopId: Int, date: LocalDate)
+
     fun editSchedule(shopId: Int, date: LocalDate)
 
     fun deleteSchedule(shopId: Int)


### PR DESCRIPTION
### 概要

HistoryScreen に食レポ追加 FAB と店舗選択ダイアログを追加し、ScheduleScreen に予定追加 FAB と店舗選択ダイアログを追加した。あわせて SelectShopDialog を共通コンポーネント化し、関連するバグ修正・UI 統一を行った。

### 主な変更点

**1. HistoryScreen への食レポ追加 FAB と店舗選択ダイアログの追加**
- 画面下部に FAB を追加し、タップで店舗選択ダイアログを表示
- エリア→店舗の順に選択して食レポ作成画面へ遷移できるようにした

**2. ScheduleScreen への予定追加 FAB と店舗選択ダイアログの追加**
- 画面下部に FAB を追加し、タップで店舗選択ダイアログ→日付選択へ遷移するフローを実装
- ダイアログ状態を `DialogState` sealed interface に統合してリファクタリング
- 過去日付を選択した際にエラーダイアログが表示されないバグを修正

**3. SelectShopDialog の共通コンポーネント化**
- HistoryScreen と ScheduleScreen で共有する `SelectShopDialog` を `ui/components/dialog/` に移動
- `confirmButtonLabel` パラメータで呼び出し元ごとにボタン文言を切り替えられるようにした

**4. DropdownAnchorField の共通コンポーネント化**
- `ShopDropdownField` 内に埋め込まれていたドロップダウンフィールドを `ui/components/dropdown/DropdownAnchorField` として切り出し

**5. FAB 位置の統一と各種バグ修正**
- HistoryScreen・ScheduleScreen の FAB 右端 padding を NoteScreen と同じ値に統一
- エリア削除時にプログレスバーが消えないバグを修正（`_editState` への誤代入を `_deleteState` に修正）

### 影響範囲

- 新規ファイル: `SelectShopDialog.kt`、`DropdownAnchorField.kt`、`SelectShopViewModel.kt`、`SelectShopViewModelContract.kt`、`MockSelectShopViewModel.kt`
- 変更ファイル: `HistoryScreen.kt`、`ScheduleScreen.kt`、`ScheduleViewModel.kt`、`ScheduleViewModelContract.kt`、`AddFab.kt`、`WideDialog.kt`、`ShopDropdownField.kt`、`EditAreaViewModel.kt`、`strings.xml`
- 破壊的変更: なし