### PR TITLE
HomeScreen の Compose Preview 表示不具合を修正

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 #Kotlin
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx3072M
+kotlin.native.jvmArgs=-Xmx4G
 
 #Gradle
-org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144M -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(compose.preview)
+            implementation(libs.compose.ui.tooling)
             implementation(libs.androidx.activity.compose)
             implementation(libs.koin.android)
             implementation(libs.accompanist.permissions)

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -138,7 +139,11 @@ fun HomeScreen(
     goToReport: (shopId: Int, shopName: String, menuName: String, iso8601Date: String) -> Unit = { _, _, _, _ -> },
     goToHistory: (reportId: Int) -> Unit = { _ -> },
     goToHistoryWithFiltering: (shopId: Int) -> Unit = { _ -> },
-    viewModel: HomeViewModelContract = koinViewModel<HomeViewModel>()
+    viewModel: HomeViewModelContract = if (LocalInspectionMode.current) {
+        MockHomeViewModel()
+    } else {
+        koinViewModel<HomeViewModel>()
+    }
 ) {
     val schedule by viewModel.schedule.collectAsStateWithLifecycle()
     val loadedScheduleState by viewModel.loadedScheduleState.collectAsStateWithLifecycle()

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
@@ -1,5 +1,6 @@
 package dev.seabat.ramennote.ui.screens.home
 
+import androidx.lifecycle.ViewModel
 import dev.seabat.ramennote.domain.model.FullReport
 import dev.seabat.ramennote.domain.model.MonthlyReportCount
 import dev.seabat.ramennote.domain.model.RunStatus
@@ -11,7 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.datetime.LocalDate
 
-class MockHomeViewModel : HomeViewModelContract {
+class MockHomeViewModel : ViewModel(), HomeViewModelContract {
     private val _schedule = MutableStateFlow<Schedule?>(Schedule())
     override val schedule: StateFlow<Schedule?> = _schedule.asStateFlow()
 


### PR DESCRIPTION
### 概要
モジュール分割後に Compose エントリポイントの Preview が表示されなくなった不具合を修正する。

### 主な変更点

**1. Preview 表示対応**
- `HomeScreen` の ViewModel デフォルト引数に `LocalInspectionMode` チェックを追加し、Preview モード時は `MockHomeViewModel` を使用するよう変更
- `MockHomeViewModel` が `ViewModel` を継承していなかった問題を修正

**2. Compose Preview ツール依存の追加**
- `sharedUI/build.gradle.kts` に `compose.ui.tooling` を追加（Preview 表示に必要なライブラリ）

**3. JVM メモリ設定の調整**
- Gradle デーモンのヒープを 4096M → 6144M に増加
- Kotlin Native コンパイラのヒープ上限として `kotlin.native.jvmArgs=-Xmx4G` を追加

### 影響範囲
- 変更ファイル: `gradle.properties`、`sharedUI/build.gradle.kts`、`HomeScreen.kt`、`MockHomeViewModel.kt`
- 破壊的変更: なし