### PR TITLE
Android 16 で AppProgressBar がクラッシュする不具合を修正

### DIFF
--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppProgressBar.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppProgressBar.kt
@@ -1,5 +1,6 @@
 package dev.seabat.ramennote.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,22 +9,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 
 @Composable
 fun AppProgressBar() {
-    Dialog(
-        onDismissRequest = {}
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.3f))
+            .pointerInput(Unit) {},
+        contentAlignment = Alignment.Center
     ) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(0.6f),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.surfaceContainerLow
-            )
-        }
+        LinearProgressIndicator(
+            modifier = Modifier.fillMaxWidth(0.6f),
+            color = MaterialTheme.colorScheme.primary,
+            trackColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
     }
 }


### PR DESCRIPTION
### 概要
Android 16 (SDK 37) 早期イメージで `AppProgressBar` 表示時にクラッシュする不具合を修正する。

### 主な変更点

**1. Dialog → Box オーバーレイへの置き換え**
- `AppProgressBar` の実装を `Dialog` から `Box` オーバーレイに変更
- `Dialog` の初期化時に `PhoneWindow.dispatchWindowAttributesChanged` が呼ばれ Android 16 でクラッシュしていた問題を回避
- 新規ウィンドウを生成しないオーバーレイ方式により、問題のあるシステムロジックを完全に回避

**2. モーダル動作の維持**
- 背景ディム（半透明の黒オーバーレイ）を追加
- `pointerInput` によるタッチイベント消費でプログレスバー表示中の操作をブロック

### 影響範囲
- 変更ファイル: `sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppProgressBar.kt`
- 破壊的変更: なし