### PR TITLE
エリア内ショップのマップ表示機能を追加

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -7,6 +8,12 @@ plugins {
     alias(libs.plugins.googleService)
     alias(libs.plugins.firebaseCrashlytics)
 }
+
+val localProperties =
+    Properties().also { props ->
+        val f = rootProject.file("local.properties")
+        if (f.exists()) f.inputStream().use { props.load(it) }
+    }
 
 android {
     namespace = "dev.seabat.ramennote"
@@ -18,6 +25,7 @@ android {
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 20
         versionName = "1.2.0"
+        manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = localProperties.getProperty("GOOGLE_MAPS_API_KEY", "")
     }
     buildFeatures {
         buildConfig = true

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${GOOGLE_MAPS_API_KEY}" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/docs/design-shops_location_screen.md
+++ b/docs/design-shops_location_screen.md
@@ -1,0 +1,167 @@
+# ShopsLocationScreen 設計ドキュメント
+
+## 概要
+
+エリアに登録されているショップの位置を Google Map 上に表示する画面。
+`NoteScreen` の `AreaItem` からマップボタンをタップして遷移する。
+
+---
+
+## 確定した設計決定
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | マップ実装 | expect/actual（Android: maps-compose、iOS: UIKitView + MapKit） |
+| 2 | 座標取得 | Google Geocoding API（Ktor、commonMain） |
+| 3 | 座標キャッシュ | ShopsLocationScreen 表示時に `mapUrl` を座標付き URL で DB 更新 |
+| 4 | Geocoding 失敗 | 該当ショップをスキップ（地図上に表示しない） |
+| 5 | ナビゲーション引数 | `ShopsLocation(areaId: Int, areaName: String)` |
+| 6 | ボタン配置 | `AreaItem` 右下、`ReportListButton` の隣 |
+| 7 | ローディング | `AppProgressBar` オーバーレイ（全件解決後に消える） |
+| 8 | iOS 実装 | iosMain Kotlin + `UIKitView` |
+| 9 | API キー | Geocoding・Maps SDK 共通1キー（`GOOGLE_MAPS_API_KEY`） |
+| 10 | AppBar タイトル | `areaName` をナビゲーション引数で渡す |
+
+---
+
+## mapUrl フォーマット
+
+| 状態 | フォーマット例 |
+|---|---|
+| 未解決（DB 登録時） | `https://www.google.com/maps/search/?api=1&query=aiya+tokushima` |
+| 解決済み（Geocoding 後） | `https://maps.google.com/?q=35.689,139.691` |
+
+画面表示時に `query=` 形式の URL を検出した場合のみ Geocoding API を呼び出し、結果で `mapUrl` を上書き保存する。次回以降は API 呼び出しなしで座標を直接利用する。
+
+---
+
+## UX フロー
+
+1. `NoteScreen` の `AreaItem` 右下のマップボタン（地図アイコン＋"マップ"テキスト）をタップ
+2. `ShopsLocationScreen` に遷移（`areaId`・`areaName` を引数で渡す）
+3. 地図を即時表示 ＋ `AppProgressBar` オーバーレイを表示
+4. 全ショップの Geocoding を並列実行
+   - 成功 → `mapUrl` を DB 更新、ピンを地図に追加
+   - 失敗 → スキップ（地図上に表示しない）
+5. 全件処理完了後に `AppProgressBar` を非表示
+6. 地図の縮尺はすべてのピンがギリギリ収まるよう自動調整
+7. ピンをタップ → `ShopScreen` に遷移
+
+---
+
+## 実装スコープ
+
+### 新規ファイル（sharedLogic）
+
+| ファイル | 役割 |
+|---|---|
+| `GeocodingRepositoryContract.kt` | Geocoding API のリポジトリ Contract |
+| `GeocodingRepository.kt` | Geocoding API の HTTP 呼び出し（Ktor） |
+| `LoadShopListByAreaIdUseCaseContract.kt` | areaId でショップ一覧取得の UseCase Contract |
+| `LoadShopListByAreaIdUseCase.kt` | areaId でショップ一覧取得の実装 |
+| `ResolveShopLocationUseCaseContract.kt` | query= URL → 座標変換 + mapUrl DB 更新の UseCase Contract |
+| `ResolveShopLocationUseCase.kt` | 座標変換 + mapUrl DB 更新の実装 |
+
+### 新規ファイル（sharedUI）
+
+| ファイル | 役割 |
+|---|---|
+| `ShopsLocationViewModelContract.kt` | ViewModel Contract |
+| `ShopsLocationViewModel.kt` | ViewModel 実装 |
+| `MockShopsLocationViewModel.kt` | Preview 用 Mock |
+| `ShopsLocationScreen.kt` | 画面 Composable |
+| `ShopsMap.common.kt` | マップ Composable の expect 宣言 |
+| `ShopsMap.android.kt` | maps-compose による Android 実装 |
+| `ShopsMap.ios.kt` | UIKitView + MapKit による iOS 実装 |
+| `ShopLocation.kt` | データクラス（`shop: Shop, lat: Double, lng: Double`） |
+
+### 既存ファイルの変更
+
+| ファイル | 変更内容 |
+|---|---|
+| `ShopDao.kt` | `updateMapUrl(shopId: Int, mapUrl: String)` 追加 |
+| `ShopsRepositoryContract.kt` | `updateMapUrl` 追加 |
+| `ShopsRepository.kt` | `updateMapUrl` 実装 |
+| `NoteScreen.kt` | `AreaItem` と `NoteScreen` に `onMapClick` コールバック追加 |
+| `MainNavigation.kt` | `Screen.ShopsLocation(areaId, areaName)` と composable ルート追加 |
+| `DataModule.common.kt` | `GeocodingRepository` を `repositoryModule` に登録 |
+| `DomainModule.kt` | 新 UseCase を登録 |
+| `ViewModelModule.kt` | `ShopsLocationViewModel` を登録 |
+| `local.properties` | `GOOGLE_MAPS_API_KEY=<キー>` 追加 |
+| `BuildSecrets.kt`（自動生成） | `GOOGLE_MAPS_API_KEY` 追加 |
+| `composeApp/build.gradle.kts` | `generateBuildSecrets` タスクに `GOOGLE_MAPS_API_KEY` 追加 |
+| `sharedUI/build.gradle.kts` | `maps-compose` 依存追加 |
+| `AndroidManifest.xml` | Maps SDK API キーの `meta-data` 追加 |
+
+---
+
+## Geocoding API
+
+- エンドポイント: `https://maps.googleapis.com/maps/api/geocode/json`
+- パラメータ: `address=<query>&key=<GOOGLE_MAPS_API_KEY>`
+- 料金: 月間 10,000 件まで無料、以降 $5.00 / 1,000 件
+
+### レスポンス（抜粋）
+
+```json
+{
+  "results": [{
+    "geometry": {
+      "location": {
+        "lat": 35.689,
+        "lng": 139.691
+      }
+    }
+  }],
+  "status": "OK"
+}
+```
+
+---
+
+## マップ Composable インターフェース
+
+```kotlin
+// commonMain
+data class ShopLocation(
+    val shop: Shop,
+    val latitude: Double,
+    val longitude: Double
+)
+
+@Composable
+expect fun ShopsMap(
+    locations: List<ShopLocation>,
+    onPinClick: (Shop) -> Unit,
+    modifier: Modifier = Modifier
+)
+```
+
+---
+
+## ViewModel ステート
+
+```kotlin
+interface ShopsLocationViewModelContract {
+    val locations: StateFlow<List<ShopLocation>>
+    val isLoading: StateFlow<Boolean>
+
+    fun loadShopsAndResolveLocations(areaId: Int)
+}
+```
+
+---
+
+## 残作業
+
+### ユーザー対応（必須）
+
+| # | 作業 | 詳細 |
+|---|---|---|
+| 1 | `GOOGLE_MAPS_API_KEY` を `local.properties` に追加 | `GOOGLE_MAPS_API_KEY=<キー>` を手動で記載。Claude Code からはフックにより編集不可。 |
+
+### 将来対応（任意）
+
+| # | 作業 | 詳細 |
+|---|---|---|
+| 2 | iOS でのピンタップ → ShopScreen 遷移 | Kotlin/Native の型バインディング制約により `MKMapViewDelegate` を Kotlin クラスで実装できなかった。Contract + Swift パターン（`SwiftLibDependencyFactoryContract` 経由）で Swift 側に委譲する方式への切り替えが必要。 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ gemini = "0.9.0"
 firebase-bom = "34.12.0"
 googleService = "4.4.4"
 firebaseCrashlyticsPlugin = "3.0.7"
+mapsCompose = "6.4.1"
 
 
 [libraries]
@@ -71,6 +72,7 @@ firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-appcheck = { module = "com.google.firebase:firebase-appcheck-playintegrity" }
 firebase-appcheck-debug = { module = "com.google.firebase:firebase-appcheck-debug" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
 
 
 [plugins]

--- a/iosApp/iosApp/Kmp/IosShopAiDataSource.swift
+++ b/iosApp/iosApp/Kmp/IosShopAiDataSource.swift
@@ -28,7 +28,9 @@ class IosShopAiDataSource: ShopAiDataSourceContract {
             ]
         )
 
-        let ai = FirebaseAI.firebaseAI(backend: .googleAI())
+        // googleAI() バックエンドは Firebase プロジェクトのプリペイドクレジットが枯渇すると利用不可になる。
+        // Vertex AI バックエンドは Google Cloud の従量課金で動作しクレジット枯渇の影響を受けないため切り替えた。
+        let ai = FirebaseAI.firebaseAI(backend: .vertexAI())
         let model = ai.generativeModel(
             modelName: "gemini-2.5-flash",
             generationConfig: GenerationConfig(

--- a/sharedLogic/build.gradle.kts
+++ b/sharedLogic/build.gradle.kts
@@ -23,6 +23,7 @@ val generateBuildSecrets by tasks.registering {
             localPropertiesFile.inputStream().use { props.load(it) }
         }
         val unsplashKey = props.getProperty("UNSPLASH_ACCESS_KEY", "")
+        val googleMapsKey = props.getProperty("GOOGLE_MAPS_API_KEY", "")
 
         val outputFile = outputDir.get().asFile.resolve("BuildSecrets.kt")
         outputFile.parentFile.mkdirs()
@@ -33,6 +34,7 @@ val generateBuildSecrets by tasks.registering {
             |// このファイルは Gradle によって自動生成されます。直接編集しないでください。
             |object BuildSecrets {
             |    const val UNSPLASH_ACCESS_KEY = "$unsplashKey"
+            |    const val GOOGLE_MAPS_API_KEY = "$googleMapsKey"
             |}
             """.trimMargin()
         )

--- a/sharedLogic/src/androidMain/kotlin/dev/seabat/ramennote/data/datasource/ShopAiDataSource.kt
+++ b/sharedLogic/src/androidMain/kotlin/dev/seabat/ramennote/data/datasource/ShopAiDataSource.kt
@@ -22,8 +22,10 @@ class ShopAiDataSource : ShopAiDataSourceContract {
                 )
             )
 
+        // googleAI() バックエンドは Firebase プロジェクト単位のプリペイドクレジットが枯渇すると利用不可になる。
+        // Vertex AI バックエンドは Google Cloud の従量課金で動作し、クレジット枯渇の影響を受けないため切り替えた。
         val model =
-            Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
+            Firebase.ai(backend = GenerativeBackend.vertexAI()).generativeModel(
                 modelName = "gemini-2.5-flash",
                 generationConfig =
                     generationConfig {

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ShopDao.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/database/dao/ShopDao.kt
@@ -37,4 +37,7 @@ interface ShopDao {
 
     @Query("SELECT * FROM shops WHERE name LIKE '%' || :query || '%'")
     suspend fun searchShopsByName(query: String): List<ShopEntity>
+
+    @Query("UPDATE shops SET mapUrl = :mapUrl WHERE id = :shopId")
+    suspend fun updateMapUrl(shopId: Int, mapUrl: String)
 }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
@@ -12,6 +12,8 @@ import dev.seabat.ramennote.data.repository.AreaImageRepository
 import dev.seabat.ramennote.data.repository.AreaImageRepositoryContract
 import dev.seabat.ramennote.data.repository.AreasRepository
 import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.data.repository.GeocodingRepository
+import dev.seabat.ramennote.data.repository.GeocodingRepositoryContract
 import dev.seabat.ramennote.data.repository.GoogleMapSearchUrlRepository
 import dev.seabat.ramennote.data.repository.GoogleMapSearchUrlRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepository
@@ -75,6 +77,20 @@ val repositoryModule =
         single<ShopsRepositoryContract> { ShopsRepository(get()) }
         single<ShopAiRepositoryContract> { ShopAiRepository(get()) }
         single<GoogleMapSearchUrlRepositoryContract> { GoogleMapSearchUrlRepository() }
+        single<GeocodingRepositoryContract> {
+            GeocodingRepository(
+                HttpClient {
+                    install(ContentNegotiation) {
+                        json(
+                            Json {
+                                ignoreUnknownKeys = true
+                                isLenient = true
+                            }
+                        )
+                    }
+                }
+            )
+        }
     }
 
 /**

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/GeocodingRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/GeocodingRepository.kt
@@ -1,0 +1,55 @@
+package dev.seabat.ramennote.data.repository
+
+import dev.seabat.ramennote.config.BuildSecrets
+import dev.seabat.ramennote.domain.model.RunStatus
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class GeocodingRepository(
+    private val httpClient: HttpClient
+) : GeocodingRepositoryContract {
+    override suspend fun geocode(query: String): RunStatus<Pair<Double, Double>> =
+        try {
+            val response: GeocodingResponse =
+                httpClient
+                    .get("https://maps.googleapis.com/maps/api/geocode/json") {
+                        parameter("address", query)
+                        parameter("key", BuildSecrets.GOOGLE_MAPS_API_KEY)
+                    }.body()
+
+            if (response.status == "OK" && response.results.isNotEmpty()) {
+                val location = response.results[0].geometry.location
+                RunStatus.Success(Pair(location.lat, location.lng))
+            } else {
+                RunStatus.Error("Geocoding 失敗: status=${response.status}")
+            }
+        } catch (e: Exception) {
+            RunStatus.Error("Geocoding エラー: ${e.message}")
+        }
+}
+
+@Serializable
+private data class GeocodingResponse(
+    val status: String,
+    val results: List<GeocodingResult>
+)
+
+@Serializable
+private data class GeocodingResult(
+    val geometry: GeocodingGeometry
+)
+
+@Serializable
+private data class GeocodingGeometry(
+    val location: GeocodingLocation
+)
+
+@Serializable
+private data class GeocodingLocation(
+    @SerialName("lat") val lat: Double,
+    @SerialName("lng") val lng: Double
+)

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/GeocodingRepositoryContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/GeocodingRepositoryContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.data.repository
+
+import dev.seabat.ramennote.domain.model.RunStatus
+
+interface GeocodingRepositoryContract {
+    suspend fun geocode(query: String): RunStatus<Pair<Double, Double>>
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepository.kt
@@ -46,6 +46,10 @@ class ShopsRepository(
     }
 
     override suspend fun getShopsByName(query: String): List<Shop> = shopDao.searchShopsByName(query).map { it.toDomainModel() }
+
+    override suspend fun updateMapUrl(shopId: Int, mapUrl: String) {
+        shopDao.updateMapUrl(shopId, mapUrl)
+    }
 }
 
 private fun ShopEntity.toDomainModel(): Shop =

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ShopsRepositoryContract.kt
@@ -21,4 +21,6 @@ interface ShopsRepositoryContract {
     suspend fun deleteShopById(id: Int)
 
     suspend fun getShopsByName(query: String): List<Shop>
+
+    suspend fun updateMapUrl(shopId: Int, mapUrl: String)
 }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -54,12 +54,16 @@ import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCase
 import dev.seabat.ramennote.domain.usecase.LoadReportsByYearUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadScheduledShopsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadScheduledShopsUseCaseContract
+import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaIdUseCase
+import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaIdUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCase
 import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCase
 import dev.seabat.ramennote.domain.usecase.LoadShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadYearlyReportStatsUseCase
 import dev.seabat.ramennote.domain.usecase.LoadYearlyReportStatsUseCaseContract
+import dev.seabat.ramennote.domain.usecase.ResolveShopLocationUseCase
+import dev.seabat.ramennote.domain.usecase.ResolveShopLocationUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SearchShopsByNameUseCase
 import dev.seabat.ramennote.domain.usecase.SearchShopsByNameUseCaseContract
 import dev.seabat.ramennote.domain.usecase.SwitchFavoriteUseCase
@@ -103,6 +107,8 @@ val useCaseModule =
         single<LoadImageUseCaseContract> { LoadImageUseCase(get()) }
         single<LoadImagePathUseCaseContract> { LoadImagePathUseCase(get()) }
         single<LoadShopListByAreaUseCaseContract> { LoadShopListByAreaUseCase(get(), get()) }
+        single<LoadShopListByAreaIdUseCaseContract> { LoadShopListByAreaIdUseCase(get()) }
+        single<ResolveShopLocationUseCaseContract> { ResolveShopLocationUseCase(get(), get()) }
         single<LoadShopUseCaseContract> { LoadShopUseCase(get()) }
         single<LoadRecentScheduleUseCaseContract> { LoadRecentScheduleUseCase(get(), get()) }
         single<LoadFullReportUseCaseContract> { LoadFullReportUseCase(get(), get(), get()) }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/ShopLocation.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/model/ShopLocation.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.domain.model
+
+data class ShopLocation(
+    val shop: Shop,
+    val latitude: Double,
+    val longitude: Double
+)

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/CreateReportPhotoNameUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/CreateReportPhotoNameUseCase.kt
@@ -1,8 +1,8 @@
 package dev.seabat.ramennote.domain.usecase
 
-import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 
 class CreateReportPhotoNameUseCase : CreateReportPhotoNameUseCaseContract {
     override fun invoke(): String {

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaIdUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaIdUseCase.kt
@@ -1,0 +1,11 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.Shop
+
+class LoadShopListByAreaIdUseCase(
+    private val shopsRepository: ShopsRepositoryContract
+) : LoadShopListByAreaIdUseCaseContract {
+    override suspend operator fun invoke(areaId: Int): List<Shop> =
+        shopsRepository.getShopsByAreaId(areaId).sortedByDescending { it.star }
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaIdUseCaseContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadShopListByAreaIdUseCaseContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.Shop
+
+interface LoadShopListByAreaIdUseCaseContract {
+    suspend operator fun invoke(areaId: Int): List<Shop>
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadYearlyReportStatsUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadYearlyReportStatsUseCase.kt
@@ -2,13 +2,13 @@ package dev.seabat.ramennote.domain.usecase
 
 import dev.seabat.ramennote.data.repository.ReportsRepositoryContract
 import dev.seabat.ramennote.domain.model.MonthlyReportCount
-import kotlin.time.Clock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 
 class LoadYearlyReportStatsUseCase(
     private val reportsRepository: ReportsRepositoryContract

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -1,0 +1,64 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.GeocodingRepositoryContract
+import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+
+/**
+ * ショップの mapUrl を解析して [ShopLocation] を返す UseCase。
+ *
+ * mapUrl の形式によって以下の2通りの処理を行う。
+ * - 座標付き URL（`?q=lat,lng`）: URL から座標を直接パースして返す
+ * - クエリ形式（`query=...`）: Geocoding API で座標を取得し mapUrl を DB に上書きしてから返す
+ *
+ * mapUrl が空または上記のいずれにも該当しない場合は `null` を返す。
+ */
+class ResolveShopLocationUseCase(
+    private val geocodingRepository: GeocodingRepositoryContract,
+    private val shopsRepository: ShopsRepositoryContract
+) : ResolveShopLocationUseCaseContract {
+    override suspend operator fun invoke(shop: Shop): ShopLocation? {
+        if (shop.mapUrl.isEmpty()) return null
+
+        return when {
+            // 既に座標付き URL（例: https://maps.google.com/?q=35.689,139.691）
+            shop.mapUrl.contains("?q=") -> parseCoordinatesFromUrl(shop)
+            // query= 形式（例: https://www.google.com/maps/search/?api=1&query=aiya+tokushima）
+            shop.mapUrl.contains("query=") -> geocodeAndUpdate(shop)
+            else -> null
+        }
+    }
+
+    /**
+     * `?q=lat,lng` 形式の URL から座標を取り出す。パース失敗時は `null` を返す。
+     */
+    private fun parseCoordinatesFromUrl(shop: Shop): ShopLocation? =
+        try {
+            val qParam = shop.mapUrl.substringAfter("?q=").substringBefore("&")
+            val parts = qParam.split(",")
+            val lat = parts[0].toDouble()
+            val lng = parts[1].toDouble()
+            ShopLocation(shop, lat, lng)
+        } catch (_: Exception) {
+            null
+        }
+
+    /**
+     * `query=` 形式の URL から店舗名クエリを取り出し Geocoding API で座標を解決する。
+     * 成功時は mapUrl を座標付き URL で DB に上書きする。失敗時は `null` を返す。
+     */
+    private suspend fun geocodeAndUpdate(shop: Shop): ShopLocation? {
+        val query = shop.mapUrl.substringAfter("query=").substringBefore("&")
+        return when (val result = geocodingRepository.geocode(query)) {
+            is RunStatus.Success -> {
+                val (lat, lng) = result.data!!
+                val newMapUrl = "https://maps.google.com/?q=$lat,$lng"
+                shopsRepository.updateMapUrl(shop.id, newMapUrl)
+                ShopLocation(shop, lat, lng)
+            }
+            else -> null
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -5,6 +5,7 @@ import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.domain.model.ShopLocation
+import io.ktor.http.decodeURLQueryComponent
 
 /**
  * ショップの mapUrl を解析して [ShopLocation] を返す UseCase。
@@ -34,12 +35,14 @@ class ResolveShopLocationUseCase(
     /**
      * `?q=lat,lng` 形式の URL から座標を取り出す。パース失敗時は `null` を返す。
      */
-    private fun parseCoordinatesFromUrl(shop: Shop): ShopLocation? =
+    private suspend fun parseCoordinatesFromUrl(shop: Shop): ShopLocation? =
         try {
             val qParam = shop.mapUrl.substringAfter("?q=").substringBefore("&")
             val parts = qParam.split(",")
             val lat = parts[0].toDouble()
             val lng = parts[1].toDouble()
+            // 日本の座標範囲外はジオコーディング誤キャッシュとみなして店舗名で再ジオコーディング
+            if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
             ShopLocation(shop, lat, lng)
         } catch (_: Exception) {
             null
@@ -49,8 +52,25 @@ class ResolveShopLocationUseCase(
      * `query=` 形式の URL から店舗名クエリを取り出し Geocoding API で座標を解決する。
      * 成功時は mapUrl を座標付き URL で DB に上書きする。失敗時は `null` を返す。
      */
+    private suspend fun geocodeByShopName(shop: Shop): ShopLocation? {
+        val query = buildString {
+            append(shop.name)
+            if (shop.stationName.isNotEmpty()) append(" ${shop.stationName}駅")
+        }
+        return when (val result = geocodingRepository.geocode(query)) {
+            is RunStatus.Success -> {
+                val (lat, lng) = result.data!!
+                val newMapUrl = "https://maps.google.com/?q=$lat,$lng"
+                shopsRepository.updateMapUrl(shop.id, newMapUrl)
+                ShopLocation(shop, lat, lng)
+            }
+            else -> null
+        }
+    }
+
     private suspend fun geocodeAndUpdate(shop: Shop): ShopLocation? {
-        val query = shop.mapUrl.substringAfter("query=").substringBefore("&")
+        // `+` はスペースの URL エンコード。decodeURLQueryComponent で正しく復元してから API に渡す。
+        val query = shop.mapUrl.substringAfter("query=").substringBefore("&").decodeURLQueryComponent()
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
                 val (lat, lng) = result.data!!

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCaseContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCaseContract.kt
@@ -1,0 +1,8 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+
+interface ResolveShopLocationUseCaseContract {
+    suspend operator fun invoke(shop: Shop): ShopLocation?
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/util/TodayLocalDate.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/util/TodayLocalDate.kt
@@ -1,9 +1,9 @@
 package dev.seabat.ramennote.domain.util
 
-import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 
 fun createTodayLocalDate(): LocalDate =
     Clock.System

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.koin.android)
             implementation(libs.accompanist.permissions)
+            implementation(libs.maps.compose)
         }
         commonMain.dependencies {
             api(projects.sharedLogic)

--- a/sharedUI/src/androidMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.android.kt
+++ b/sharedUI/src/androidMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.android.kt
@@ -39,10 +39,7 @@ actual fun ShopsMap(
                 state = MarkerState(LatLng(shopLocation.latitude, shopLocation.longitude)),
                 title = shopLocation.shop.name,
                 snippet = shopLocation.shop.category.ifEmpty { null },
-                onClick = {
-                    onPinClick(shopLocation.shop)
-                    true
-                }
+                onInfoWindowClick = { onPinClick(shopLocation.shop) }
             )
         }
     }

--- a/sharedUI/src/androidMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.android.kt
+++ b/sharedUI/src/androidMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.android.kt
@@ -1,0 +1,49 @@
+package dev.seabat.ramennote.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+
+@Composable
+actual fun ShopsMap(
+    locations: List<ShopLocation>,
+    onPinClick: (Shop) -> Unit,
+    modifier: Modifier
+) {
+    val cameraPositionState = rememberCameraPositionState()
+
+    LaunchedEffect(locations) {
+        if (locations.isNotEmpty()) {
+            val boundsBuilder = LatLngBounds.builder()
+            locations.forEach { boundsBuilder.include(LatLng(it.latitude, it.longitude)) }
+            val bounds = boundsBuilder.build()
+            cameraPositionState.animate(CameraUpdateFactory.newLatLngBounds(bounds, 120))
+        }
+    }
+
+    GoogleMap(
+        modifier = modifier,
+        cameraPositionState = cameraPositionState
+    ) {
+        locations.forEach { shopLocation ->
+            Marker(
+                state = MarkerState(LatLng(shopLocation.latitude, shopLocation.longitude)),
+                title = shopLocation.shop.name,
+                snippet = shopLocation.shop.category.ifEmpty { null },
+                onClick = {
+                    onPinClick(shopLocation.shop)
+                    true
+                }
+            )
+        }
+    }
+}

--- a/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="note_notification">カードを長押しすると編集できます</string>
     <string name="note_search_hint">店舗名を入力して下さい</string>
     <string name="note_hit_count">%1$s件見つかりました。</string>
+    <string name="note_map_button">地図</string>
 
 
     <!-- Edit Area Screen -->

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppProgressBar.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppProgressBar.kt
@@ -15,10 +15,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 @Composable
 fun AppProgressBar() {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.3f))
-            .pointerInput(Unit) {},
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.3f))
+                .pointerInput(Unit) {},
         contentAlignment = Alignment.Center
     ) {
         LinearProgressIndicator(

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.common.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.common.kt
@@ -1,0 +1,13 @@
+package dev.seabat.ramennote.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+
+@Composable
+expect fun ShopsMap(
+    locations: List<ShopLocation>,
+    onPinClick: (Shop) -> Unit,
+    modifier: Modifier = Modifier
+)

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ActionButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ActionButton.kt
@@ -42,7 +42,7 @@ fun ActionButton(
         contentAlignment = Alignment.Center
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/di/ViewModelModule.kt
@@ -13,6 +13,7 @@ import dev.seabat.ramennote.ui.screens.note.editareasort.EditAreaSortViewModel
 import dev.seabat.ramennote.ui.screens.note.editshop.EditShopViewModel
 import dev.seabat.ramennote.ui.screens.note.shop.ShopViewModel
 import dev.seabat.ramennote.ui.screens.note.shoplist.AreaShopListViewModel
+import dev.seabat.ramennote.ui.screens.note.shopslocation.ShopsLocationViewModel
 import dev.seabat.ramennote.ui.screens.schedule.ScheduleViewModel
 import dev.seabat.ramennote.ui.screens.settings.SettingsViewModel
 import org.koin.core.module.dsl.viewModel
@@ -35,4 +36,5 @@ val viewModelModule =
         viewModel { ShopViewModel(get(), get(), get(), get(), get(), get()) }
         viewModel { ScheduleViewModel(get(), get(), get()) }
         viewModel { SettingsViewModel(get()) }
+        viewModel { ShopsLocationViewModel(get(), get()) }
     }

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
@@ -46,6 +46,7 @@ import dev.seabat.ramennote.ui.screens.note.editareasort.EditAreaSortScreen
 import dev.seabat.ramennote.ui.screens.note.editshop.EditShopScreen
 import dev.seabat.ramennote.ui.screens.note.shop.ShopScreen
 import dev.seabat.ramennote.ui.screens.note.shoplist.AreaShopListScreen
+import dev.seabat.ramennote.ui.screens.note.shopslocation.ShopsLocationScreen
 import dev.seabat.ramennote.ui.screens.schedule.ScheduleScreen
 import dev.seabat.ramennote.ui.screens.settings.SettingsScreen
 import kotlinx.datetime.LocalDate
@@ -247,6 +248,20 @@ sealed interface Screen {
 
         @Composable
         override fun getTitle(): String = "レポート編集"
+    }
+
+    @Serializable
+    data class ShopsLocation(
+        val areaId: Int,
+        val areaName: String
+    ) : Screen {
+        override val route: String = getRouteName(ShopsLocation::class)
+
+        @Composable
+        override fun getIcon(): ImageVector = Icons.Default.Star
+
+        @Composable
+        override fun getTitle(): String = areaName
     }
 
     val route: String
@@ -452,6 +467,9 @@ fun MainNavigation() {
                                         saveState = true
                                     }
                                 }
+                            },
+                            goToShopsLocation = { areaId, areaName ->
+                                navController.navigate(Screen.ShopsLocation(areaId, areaName))
                             }
                         )
                     }
@@ -608,6 +626,17 @@ fun MainNavigation() {
                         EditReportScreen(
                             reportId = screen.reportId,
                             onBackClick = { navController.popBackStack() }
+                        )
+                    }
+                    composable<Screen.ShopsLocation> { backStackEntry ->
+                        val screen: Screen.ShopsLocation = backStackEntry.toRoute()
+                        ShopsLocationScreen(
+                            areaId = screen.areaId,
+                            areaName = screen.areaName,
+                            onBackClick = { navController.popBackStack() },
+                            onShopClick = { shop ->
+                                navController.navigate(Screen.Shop(shop.id, shop.name))
+                            }
                         )
                     }
                 }

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
@@ -41,7 +41,6 @@ import dev.seabat.ramennote.ui.screens.componens.ShopInputField
 import dev.seabat.ramennote.ui.share.createPostText
 import dev.seabat.ramennote.ui.share.createRememberedXShareLauncher
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -54,6 +53,7 @@ import ramennote.sharedui.generated.resources.report_impressions
 import ramennote.sharedui.generated.resources.report_post_x
 import ramennote.sharedui.generated.resources.report_run
 import ramennote.sharedui.generated.resources.report_shop_name
+import kotlin.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
@@ -36,7 +36,6 @@ import dev.seabat.ramennote.ui.screens.componens.ReportStarRatingItem
 import dev.seabat.ramennote.ui.screens.componens.ShopDetailItem
 import dev.seabat.ramennote.ui.screens.componens.ShopInputField
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
@@ -49,6 +48,7 @@ import ramennote.sharedui.generated.resources.report_delete_confirm
 import ramennote.sharedui.generated.resources.report_header
 import ramennote.sharedui.generated.resources.report_impressions
 import ramennote.sharedui.generated.resources.report_shop_name
+import kotlin.time.Instant
 
 private sealed interface ErrorDialogType {
     object Hidden : ErrorDialogType

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -79,7 +79,6 @@ import dev.seabat.ramennote.ui.share.createRememberedXShareLauncher
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import dev.seabat.ramennote.ui.util.createFormattedDateString
 import kotlinx.datetime.DatePeriod
-import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
@@ -105,6 +104,7 @@ import ramennote.sharedui.generated.resources.home_schedule_date
 import ramennote.sharedui.generated.resources.home_today_schedule
 import ramennote.sharedui.generated.resources.home_tomorrow_schedule
 import ramennote.sharedui.generated.resources.schedule_picker_label
+import kotlin.time.Instant
 
 private const val FAVORITE_SHOP_ITEM_HEIGHT = 66
 
@@ -139,11 +139,12 @@ fun HomeScreen(
     goToReport: (shopId: Int, shopName: String, menuName: String, iso8601Date: String) -> Unit = { _, _, _, _ -> },
     goToHistory: (reportId: Int) -> Unit = { _ -> },
     goToHistoryWithFiltering: (shopId: Int) -> Unit = { _ -> },
-    viewModel: HomeViewModelContract = if (LocalInspectionMode.current) {
-        MockHomeViewModel()
-    } else {
-        koinViewModel<HomeViewModel>()
-    }
+    viewModel: HomeViewModelContract =
+        if (LocalInspectionMode.current) {
+            MockHomeViewModel()
+        } else {
+            koinViewModel<HomeViewModel>()
+        }
 ) {
     val schedule by viewModel.schedule.collectAsStateWithLifecycle()
     val loadedScheduleState by viewModel.loadedScheduleState.collectAsStateWithLifecycle()

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/MockHomeViewModel.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.datetime.LocalDate
 
-class MockHomeViewModel : ViewModel(), HomeViewModelContract {
+class MockHomeViewModel :
+    ViewModel(),
+    HomeViewModelContract {
     private val _schedule = MutableStateFlow<Schedule?>(Schedule())
     override val schedule: StateFlow<Schedule?> = _schedule.asStateFlow()
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -63,9 +63,11 @@ import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
+import ramennote.sharedui.generated.resources.location_on_24px
 import ramennote.sharedui.generated.resources.note_background
 import ramennote.sharedui.generated.resources.note_hit_count
 import ramennote.sharedui.generated.resources.note_item_count
+import ramennote.sharedui.generated.resources.note_map_button
 import ramennote.sharedui.generated.resources.note_no_data
 import ramennote.sharedui.generated.resources.note_notification
 import ramennote.sharedui.generated.resources.note_search_hint
@@ -82,6 +84,7 @@ fun NoteScreen(
     goToEditAreaSort: () -> Unit = {},
     goToShop: (Shop) -> Unit = {},
     goToHistoryWithAreaFiltering: (areaId: Int) -> Unit = {},
+    goToShopsLocation: (areaId: Int, areaName: String) -> Unit = { _, _ -> },
     viewModel: NoteViewModelContract = koinViewModel<NoteViewModel>()
 ) {
     Column(
@@ -99,6 +102,7 @@ fun NoteScreen(
             onSortClick = goToEditAreaSort,
             onShopClick = goToShop,
             onAreaReportClick = goToHistoryWithAreaFiltering,
+            onMapClick = goToShopsLocation,
             initialSearchText = initialSearchText
         )
     }
@@ -119,6 +123,7 @@ private fun MainContent(
     onSortClick: () -> Unit = {},
     onShopClick: (Shop) -> Unit = {},
     onAreaReportClick: (areaId: Int) -> Unit = {},
+    onMapClick: (areaId: Int, areaName: String) -> Unit = { _, _ -> },
     initialSearchText: String = ""
 ) {
     BoxWithConstraints(
@@ -251,7 +256,8 @@ private fun MainContent(
                                     itemCount = "${area.count}${stringResource(Res.string.note_item_count)}",
                                     onClick = { onAreaClick(area.name) },
                                     onLongClick = { onAreaLongClick(area.areaId) },
-                                    onReportClick = { onAreaReportClick(area.areaId) }
+                                    onReportClick = { onAreaReportClick(area.areaId) },
+                                    onMapClick = { onMapClick(area.areaId, area.name) }
                                 )
                             }
                         }
@@ -320,7 +326,8 @@ private fun AreaItem(
     itemCount: String,
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
-    onReportClick: () -> Unit = {}
+    onReportClick: () -> Unit = {},
+    onMapClick: () -> Unit = {}
 ) {
     Card(
         modifier =
@@ -396,6 +403,11 @@ private fun AreaItem(
                                 fontWeight = FontWeight.Bold
                             ),
                         color = Color.White.copy(alpha = 0.8f)
+                    )
+                    ActionButton(
+                        icon = vectorResource(Res.drawable.location_on_24px),
+                        text = stringResource(Res.string.note_map_button),
+                        onClick = onMapClick
                     )
                     ReportListButton(onClick = onReportClick)
                 }

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -50,7 +50,6 @@ import dev.seabat.ramennote.ui.screens.componens.ShopMultilineInputField
 import dev.seabat.ramennote.ui.screens.componens.ShopStarRatingItem
 import dev.seabat.ramennote.ui.screens.note.categoryList
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import kotlin.time.Clock
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -65,6 +64,7 @@ import ramennote.sharedui.generated.resources.add_shop_register_button
 import ramennote.sharedui.generated.resources.add_shop_title
 import ramennote.sharedui.generated.resources.add_station_label
 import ramennote.sharedui.generated.resources.add_web_site_label
+import kotlin.time.Clock
 
 @Composable
 fun AddShopScreen(

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
@@ -52,7 +52,6 @@ import dev.seabat.ramennote.ui.screens.componens.ShopDetailItem
 import dev.seabat.ramennote.ui.screens.componens.ShopStarRatingRow
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import dev.seabat.ramennote.ui.util.createFormattedDateString
-import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -75,6 +74,7 @@ import ramennote.sharedui.generated.resources.favorite_disabled
 import ramennote.sharedui.generated.resources.favorite_enabled
 import ramennote.sharedui.generated.resources.schedule_picker_label
 import ramennote.sharedui.generated.resources.shop_map_label
+import kotlin.time.Instant
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/MockShopsLocationViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/MockShopsLocationViewModel.kt
@@ -1,0 +1,38 @@
+package dev.seabat.ramennote.ui.screens.note.shopslocation
+
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class MockShopsLocationViewModel : ShopsLocationViewModelContract {
+    override val locations: StateFlow<List<ShopLocation>> =
+        MutableStateFlow(
+            listOf(
+                ShopLocation(
+                    shop = Shop(id = 1, name = "一風堂", areaId = 1, shopUrl = "", mapUrl = "", star = 4, stationName = "渋谷", category = "豚骨"),
+                    latitude = 35.6595,
+                    longitude = 139.7004
+                ),
+                ShopLocation(
+                    shop =
+                        Shop(
+                            id = 2,
+                            name = "博多風龍",
+                            areaId = 1,
+                            shopUrl = "",
+                            mapUrl = "",
+                            star = 3,
+                            stationName = "新宿",
+                            category = "豚骨"
+                        ),
+                    latitude = 35.6917,
+                    longitude = 139.7006
+                )
+            )
+        )
+
+    override val isLoading: StateFlow<Boolean> = MutableStateFlow(false)
+
+    override fun loadShopsAndResolveLocations(areaId: Int) {}
+}

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
@@ -1,0 +1,66 @@
+package dev.seabat.ramennote.ui.screens.note.shopslocation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.ui.components.AppBar
+import dev.seabat.ramennote.ui.components.AppProgressBar
+import dev.seabat.ramennote.ui.components.ShopsMap
+import dev.seabat.ramennote.ui.theme.RamenNoteTheme
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun ShopsLocationScreen(
+    areaId: Int,
+    areaName: String,
+    onBackClick: () -> Unit,
+    onShopClick: (Shop) -> Unit,
+    viewModel: ShopsLocationViewModelContract = koinViewModel<ShopsLocationViewModel>()
+) {
+    val locations by viewModel.locations.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    LaunchedEffect(areaId) {
+        viewModel.loadShopsAndResolveLocations(areaId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        AppBar(
+            title = areaName,
+            onBackClick = onBackClick
+        )
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            ShopsMap(
+                locations = locations,
+                onPinClick = onShopClick,
+                modifier = Modifier.fillMaxSize()
+            )
+
+            if (isLoading) {
+                AppProgressBar()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ShopsLocationScreenPreview() {
+    RamenNoteTheme {
+        ShopsLocationScreen(
+            areaId = 1,
+            areaName = "東京",
+            onBackClick = {},
+            onShopClick = {},
+            viewModel = MockShopsLocationViewModel()
+        )
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationViewModel.kt
@@ -1,0 +1,45 @@
+package dev.seabat.ramennote.ui.screens.note.shopslocation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.seabat.ramennote.domain.model.ShopLocation
+import dev.seabat.ramennote.domain.usecase.LoadShopListByAreaIdUseCaseContract
+import dev.seabat.ramennote.domain.usecase.ResolveShopLocationUseCaseContract
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ShopsLocationViewModel(
+    private val loadShopListByAreaIdUseCase: LoadShopListByAreaIdUseCaseContract,
+    private val resolveShopLocationUseCase: ResolveShopLocationUseCaseContract
+) : ViewModel(),
+    ShopsLocationViewModelContract {
+    private val _locations = MutableStateFlow<List<ShopLocation>>(emptyList())
+    override val locations: StateFlow<List<ShopLocation>> = _locations.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    override val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    override fun loadShopsAndResolveLocations(areaId: Int) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _locations.value = emptyList()
+
+            val shops = loadShopListByAreaIdUseCase(areaId)
+
+            // 全ショップの Geocoding を並列実行し、完了後にまとめてリストに反映
+            val resolved =
+                shops
+                    .map { shop ->
+                        async { resolveShopLocationUseCase(shop) }
+                    }.awaitAll()
+                    .filterNotNull()
+
+            _locations.value = resolved
+            _isLoading.value = false
+        }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationViewModelContract.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationViewModelContract.kt
@@ -1,0 +1,11 @@
+package dev.seabat.ramennote.ui.screens.note.shopslocation
+
+import dev.seabat.ramennote.domain.model.ShopLocation
+import kotlinx.coroutines.flow.StateFlow
+
+interface ShopsLocationViewModelContract {
+    val locations: StateFlow<List<ShopLocation>>
+    val isLoading: StateFlow<Boolean>
+
+    fun loadShopsAndResolveLocations(areaId: Int)
+}

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -42,7 +42,6 @@ import dev.seabat.ramennote.ui.components.button.AddFab
 import dev.seabat.ramennote.ui.components.dialog.SelectShopDialog
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import dev.seabat.ramennote.ui.util.dayOfWeekJp
-import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -60,6 +59,7 @@ import ramennote.sharedui.generated.resources.schedule_no_data
 import ramennote.sharedui.generated.resources.schedule_picker_label
 import ramennote.sharedui.generated.resources.screen_schedule_title
 import ramennote.sharedui.generated.resources.select_shop_dialog_create_schedule_button
+import kotlin.time.Instant
 
 private sealed interface DialogState {
     object Hidden : DialogState
@@ -188,7 +188,6 @@ private fun ScheduleScreenDialog(
                             datePickerOnClickHandler(
                                 addDatePickerState,
                                 showErrorDialog = onShowPastDate,
-
                                 dismissDatePicker = onDismiss,
                                 editSchedule = { date -> onAddSchedule(state.shop.id, date) }
                             )
@@ -218,7 +217,6 @@ private fun ScheduleScreenDialog(
                             datePickerOnClickHandler(
                                 editDatePickerState,
                                 showErrorDialog = onShowPastDate,
-
                                 dismissDatePicker = onDismiss,
                                 editSchedule = { date -> onEditSchedule(state.shopId, date) }
                             )

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
@@ -1,6 +1,7 @@
 package dev.seabat.ramennote.ui.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.UIKitView
@@ -20,6 +21,8 @@ actual fun ShopsMap(
     modifier: Modifier
 ) {
     val locationsState = rememberUpdatedState(locations)
+    // Kotlin/Native の GC による回収を防ぐため Kotlin 側でも強参照を保持する
+    val annotationRefs = remember { mutableListOf<MKPointAnnotation>() }
 
     UIKitView(
         factory = { MKMapView() },
@@ -27,6 +30,7 @@ actual fun ShopsMap(
             val currentLocations = locationsState.value
 
             mapView.removeAnnotations(mapView.annotations)
+            annotationRefs.clear()
 
             currentLocations.forEach { shopLocation ->
                 val annotation =
@@ -37,6 +41,7 @@ actual fun ShopsMap(
                         setTitle(shopLocation.shop.name)
                         setSubtitle(shopLocation.shop.stationName.ifEmpty { shopLocation.shop.category })
                     }
+                annotationRefs.add(annotation)
                 mapView.addAnnotation(annotation)
             }
 
@@ -71,7 +76,8 @@ private fun fitMapToLocations(
     val centerLng = (minLng + maxLng) / 2.0
     val latDelta = (maxLat - minLat) * 1.5 + 0.01
     val lngDelta = (maxLng - minLng) * 1.5 + 0.01
-    val spanMeters = maxOf(latDelta, lngDelta) * 111_000.0
+    // MKCoordinateRegionMakeWithDistance の spanMeters が大きすぎると Invalid Region でクラッシュするため上限を設ける
+    val spanMeters = minOf(maxOf(latDelta, lngDelta) * 111_000.0, 10_000_000.0)
 
     val region =
         MKCoordinateRegionMakeWithDistance(

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
@@ -9,9 +9,12 @@ import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.domain.model.ShopLocation
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.CoreLocation.CLLocationCoordinate2DMake
+import platform.MapKit.MKAnnotationView
 import platform.MapKit.MKCoordinateRegionMakeWithDistance
 import platform.MapKit.MKMapView
+import platform.MapKit.MKMapViewDelegateProtocol
 import platform.MapKit.MKPointAnnotation
+import platform.darwin.NSObject
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
@@ -21,8 +24,10 @@ actual fun ShopsMap(
     modifier: Modifier
 ) {
     val locationsState = rememberUpdatedState(locations)
+    val onPinClickState = rememberUpdatedState(onPinClick)
     // Kotlin/Native の GC による回収を防ぐため Kotlin 側でも強参照を保持する
     val annotationRefs = remember { mutableListOf<MKPointAnnotation>() }
+    val delegateRef = remember { mutableListOf<ShopsMapDelegate>() }
 
     UIKitView(
         factory = { MKMapView() },
@@ -45,12 +50,43 @@ actual fun ShopsMap(
                 mapView.addAnnotation(annotation)
             }
 
+            val delegate = ShopsMapDelegate(
+                annotationRefs = annotationRefs.toList(),
+                shopLocations = currentLocations,
+                onPinClick = onPinClickState.value
+            )
+            delegateRef.clear()
+            delegateRef.add(delegate)
+            mapView.delegate = delegate
+
             if (currentLocations.isNotEmpty()) {
                 fitMapToLocations(mapView, currentLocations)
             }
         },
         modifier = modifier
     )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private class ShopsMapDelegate(
+    private val annotationRefs: List<MKPointAnnotation>,
+    private val shopLocations: List<ShopLocation>,
+    private val onPinClick: (Shop) -> Unit
+) : NSObject(), MKMapViewDelegateProtocol {
+    override fun mapView(mapView: MKMapView, didSelectAnnotationView: MKAnnotationView) {
+        val tappedAnnotation = didSelectAnnotationView.annotation ?: return
+        mapView.deselectAnnotation(tappedAnnotation, animated = false)
+
+        // isEqual による比較、失敗時はタイトル（店名）でフォールバック
+        val idx = annotationRefs.indexOfFirst { it == tappedAnnotation }
+            .takeIf { it >= 0 }
+            ?: run {
+                val title = (tappedAnnotation as? MKPointAnnotation)?.title()
+                shopLocations.indexOfFirst { it.shop.name == title }
+            }
+
+        if (idx >= 0) onPinClick(shopLocations[idx].shop)
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/ShopsMap.ios.kt
@@ -1,0 +1,83 @@
+package dev.seabat.ramennote.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import dev.seabat.ramennote.domain.model.Shop
+import dev.seabat.ramennote.domain.model.ShopLocation
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreLocation.CLLocationCoordinate2DMake
+import platform.MapKit.MKCoordinateRegionMakeWithDistance
+import platform.MapKit.MKMapView
+import platform.MapKit.MKPointAnnotation
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun ShopsMap(
+    locations: List<ShopLocation>,
+    onPinClick: (Shop) -> Unit,
+    modifier: Modifier
+) {
+    val locationsState = rememberUpdatedState(locations)
+
+    UIKitView(
+        factory = { MKMapView() },
+        update = { mapView ->
+            val currentLocations = locationsState.value
+
+            mapView.removeAnnotations(mapView.annotations)
+
+            currentLocations.forEach { shopLocation ->
+                val annotation =
+                    MKPointAnnotation().apply {
+                        setCoordinate(
+                            CLLocationCoordinate2DMake(shopLocation.latitude, shopLocation.longitude)
+                        )
+                        setTitle(shopLocation.shop.name)
+                        setSubtitle(shopLocation.shop.stationName.ifEmpty { shopLocation.shop.category })
+                    }
+                mapView.addAnnotation(annotation)
+            }
+
+            if (currentLocations.isNotEmpty()) {
+                fitMapToLocations(mapView, currentLocations)
+            }
+        },
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun fitMapToLocations(
+    mapView: MKMapView,
+    locations: List<ShopLocation>
+) {
+    if (locations.isEmpty()) return
+
+    var minLat = locations[0].latitude
+    var maxLat = locations[0].latitude
+    var minLng = locations[0].longitude
+    var maxLng = locations[0].longitude
+
+    locations.forEach { loc ->
+        if (loc.latitude < minLat) minLat = loc.latitude
+        if (loc.latitude > maxLat) maxLat = loc.latitude
+        if (loc.longitude < minLng) minLng = loc.longitude
+        if (loc.longitude > maxLng) maxLng = loc.longitude
+    }
+
+    val centerLat = (minLat + maxLat) / 2.0
+    val centerLng = (minLng + maxLng) / 2.0
+    val latDelta = (maxLat - minLat) * 1.5 + 0.01
+    val lngDelta = (maxLng - minLng) * 1.5 + 0.01
+    val spanMeters = maxOf(latDelta, lngDelta) * 111_000.0
+
+    val region =
+        MKCoordinateRegionMakeWithDistance(
+            CLLocationCoordinate2DMake(centerLat, centerLng),
+            spanMeters,
+            spanMeters
+        )
+    mapView.setRegion(region, animated = true)
+}


### PR DESCRIPTION
### 概要
NoteScreen のエリアから地図ボタンをタップすると、そのエリアに登録されているショップの位置をマップ上にピン表示する ShopsLocationScreen を追加した。

### 主な変更点

**1. ShopsLocationScreen の新規追加**
- NoteScreen の AreaItem 右下に「地図」ボタンを追加
- ショップの住所を Geocoding API（Ktor）で座標変換し、マップ上にピン表示
- 座標は DB にキャッシュし、次回以降は API 呼び出しなしで表示
- ピンタップで吹き出し（店名・カテゴリ）を表示し、吹き出しタップで ShopScreen に遷移（Android）
- ピンタップで ShopScreen に直接遷移（iOS）

**2. ジオコーディングの不具合修正**
- URL 中の `+` をスペースとして正しくデコードしてから Geocoding API に渡すよう修正
- 誤キャッシュされた日本範囲外の座標を検出し、店舗名で再ジオコーディングするフォールバックを追加

**3. iOS マップの安定化**
- `MKAnnotation` オブジェクトの GC 対策として Kotlin 側に強参照リストを保持
- `fitMapToLocations` の span 値に上限を設けてクラッシュを防止
- `MKMapViewDelegateProtocol` を Kotlin/Native で実装してピンタップナビゲーションを実現

**4. Gemini バックエンドの切り替え**
- Firebase プロジェクトのプリペイドクレジット枯渇に伴い、Android・iOS ともに `googleAI` から `vertexAI` バックエンドへ切り替え

### 影響範囲
- 新規ファイル: `ShopsLocationScreen.kt`、`ShopsLocationViewModel.kt`、`GeocodingRepository.kt`、`ResolveShopLocationUseCase.kt`、`LoadShopListByAreaIdUseCase.kt`、`ShopsMap.common/android/ios.kt`、`ShopLocation.kt`
- 変更ファイル: `NoteScreen.kt`、`MainNavigation.kt`、`ShopDao.kt`、`ShopsRepository.kt`、`DataModule.common.kt`、`DomainModule.kt`、`ViewModelModule.kt`、`AndroidManifest.xml`、`build.gradle.kts`（各モジュール）、`IosShopAiDataSource.swift`、`ShopAiDataSource.kt`
- 破壊的変更: なし