### PR TITLE
地図 URL を /maps?q= 形式に変更してピン表示とズームを両立

### DIFF
--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -10,8 +10,9 @@ import io.ktor.http.decodeURLQueryComponent
 /**
  * ショップの mapUrl を解析して [ShopLocation] を返す UseCase。
  *
- * mapUrl の形式によって以下の2通りの処理を行う。
- * - 座標付き URL（`?q=lat,lng`）: URL から座標を直接パースして返す
+ * mapUrl の形式によって以下の3通りの処理を行う。
+ * - 座標付き URL（`/maps?q=lat,lng&z=16`）: URL から座標を直接パースして返す
+ * - 旧座標付き URL（`?q=lat,lng`）: 座標をパースし /maps?q= 形式で DB を上書きしてから返す
  * - クエリ形式（`query=...`）: Geocoding API で座標を取得し mapUrl を DB に上書きしてから返す
  *
  * mapUrl が空または上記のいずれにも該当しない場合は `null` を返す。
@@ -24,8 +25,10 @@ class ResolveShopLocationUseCase(
         if (shop.mapUrl.isEmpty()) return null
 
         return when {
-            // 既に座標付き URL（例: https://maps.google.com/?q=35.689,139.691）
-            shop.mapUrl.contains("?q=") -> parseCoordinatesFromUrl(shop)
+            // 座標付き URL（例: https://maps.google.com/maps?q=35.689,139.691&z=16）
+            shop.mapUrl.contains("maps.google.com/maps?q=") -> parseCoordinatesFromMapsQUrl(shop)
+            // 旧座標付き URL（例: https://maps.google.com/?q=35.689,139.691）→ /maps?q= 形式へ移行
+            shop.mapUrl.contains("?q=") -> parseCoordinatesFromQUrl(shop)
             // query= 形式（例: https://www.google.com/maps/search/?api=1&query=aiya+tokushima）
             shop.mapUrl.contains("query=") -> geocodeAndUpdate(shop)
             else -> null
@@ -33,16 +36,33 @@ class ResolveShopLocationUseCase(
     }
 
     /**
-     * `?q=lat,lng` 形式の URL から座標を取り出す。パース失敗時は `null` を返す。
+     * `/maps?q=lat,lng&z=16` 形式の URL から座標を取り出す。パース失敗時は `null` を返す。
      */
-    private suspend fun parseCoordinatesFromUrl(shop: Shop): ShopLocation? =
+    private suspend fun parseCoordinatesFromMapsQUrl(shop: Shop): ShopLocation? =
         try {
-            val qParam = shop.mapUrl.substringAfter("?q=").substringBefore("&")
+            val qParam = shop.mapUrl.substringAfter("maps.google.com/maps?q=").substringBefore("&")
             val parts = qParam.split(",")
             val lat = parts[0].toDouble()
             val lng = parts[1].toDouble()
             // 日本の座標範囲外はジオコーディング誤キャッシュとみなして店舗名で再ジオコーディング
             if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
+            ShopLocation(shop, lat, lng)
+        } catch (_: Exception) {
+            null
+        }
+
+    /**
+     * 旧形式 `?q=lat,lng` の URL から座標をパースし、/maps?q= 形式で DB を上書きする。
+     */
+    private suspend fun parseCoordinatesFromQUrl(shop: Shop): ShopLocation? =
+        try {
+            val qParam = shop.mapUrl.substringAfter("?q=").substringBefore("&")
+            val parts = qParam.split(",")
+            val lat = parts[0].toDouble()
+            val lng = parts[1].toDouble()
+            if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
+            val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
+            shopsRepository.updateMapUrl(shop.id, newMapUrl)
             ShopLocation(shop, lat, lng)
         } catch (_: Exception) {
             null
@@ -60,7 +80,7 @@ class ResolveShopLocationUseCase(
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
                 val (lat, lng) = result.data!!
-                val newMapUrl = "https://maps.google.com/?q=$lat,$lng"
+                val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
             }
@@ -74,7 +94,7 @@ class ResolveShopLocationUseCase(
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
                 val (lat, lng) = result.data!!
-                val newMapUrl = "https://maps.google.com/?q=$lat,$lng"
+                val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
             }


### PR DESCRIPTION
### 概要
Google マップで店舗位置を開いた際にズームが効かず縮小表示になる問題と、ピンが表示されない問題を修正する。

### 主な変更点

**1. mapUrl の形式変更**
- ジオコーディング結果の保存 URL を `https://maps.google.com/?q=lat,lng` から `https://maps.google.com/maps?q=lat,lng&z=16` に変更
- `/maps` パスを追加することで `z=16`（ズームレベル）が有効になり、`?q=` によるピン表示も維持

**2. 旧形式 URL の自動移行**
- DB に残存する旧形式（`?q=lat,lng`）の URL は、マップ画面を開いたタイミングで新形式へ自動上書き（遅延マイグレーション）

### 影響範囲
- 新規ファイル: なし
- 変更ファイル: `ResolveShopLocationUseCase.kt`
- 破壊的変更: なし