### PR TITLE
mapUrl の Google Maps 短縮 URL 対応と表示形式の改善

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.seabat.ramennote"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 20
-        versionName = "1.2.0"
+        versionCode = 21
+        versionName = "1.3.0"
         manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = localProperties.getProperty("GOOGLE_MAPS_API_KEY", "")
     }
     buildFeatures {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -221,7 +221,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -241,7 +241,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -257,7 +257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
@@ -12,6 +12,8 @@ import dev.seabat.ramennote.data.repository.AreaImageRepository
 import dev.seabat.ramennote.data.repository.AreaImageRepositoryContract
 import dev.seabat.ramennote.data.repository.AreasRepository
 import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.data.repository.ExpandShortUrlRepository
+import dev.seabat.ramennote.data.repository.ExpandShortUrlRepositoryContract
 import dev.seabat.ramennote.data.repository.GeocodingRepository
 import dev.seabat.ramennote.data.repository.GeocodingRepositoryContract
 import dev.seabat.ramennote.data.repository.GoogleMapSearchUrlRepository
@@ -90,6 +92,10 @@ val repositoryModule =
                     }
                 }
             )
+        }
+        single<ExpandShortUrlRepositoryContract> {
+            // HttpRedirect プラグイン未使用＝リダイレクト非自動追跡。手動で Location ヘッダーを辿る。
+            ExpandShortUrlRepository(HttpClient())
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/di/DataModule.common.kt
@@ -31,6 +31,7 @@ import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.data.repository.UnsplashImageRepository
 import dev.seabat.ramennote.data.repository.UnsplashImageRepositoryContract
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpRedirect
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
@@ -94,8 +95,15 @@ val repositoryModule =
             )
         }
         single<ExpandShortUrlRepositoryContract> {
-            // HttpRedirect プラグイン未使用＝リダイレクト非自動追跡。手動で Location ヘッダーを辿る。
-            ExpandShortUrlRepository(HttpClient())
+            ExpandShortUrlRepository(
+                HttpClient {
+                    // Ktor 層でリダイレクトを追跡することで iOS Darwin エンジンの
+                    // NSURLSession による透過リダイレクトを回避し、最終 URL を取得できる
+                    install(HttpRedirect) {
+                        checkHttpMethod = false
+                    }
+                }
+            )
         }
     }
 

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepository.kt
@@ -9,24 +9,16 @@ import io.ktor.http.HttpHeaders
 class ExpandShortUrlRepository(
     private val httpClient: HttpClient
 ) : ExpandShortUrlRepositoryContract {
+    // HttpRedirect プラグインが Ktor 層でリダイレクトを追跡するため、
+    // 最終リダイレクト先の URL は response.request.url から取得できる
     override suspend fun expand(shortUrl: String): RunStatus<String> =
         try {
-            var currentUrl = shortUrl
-            // maps.app.goo.gl は複数回リダイレクトする場合があるため最大10回追跡する
-            repeat(10) {
-                val response = httpClient.get(currentUrl) {
-                    headers {
-                        append(HttpHeaders.UserAgent, "Mozilla/5.0")
-                    }
-                }
-                val location = response.headers[HttpHeaders.Location]
-                if (response.status.value in 300..399 && location != null) {
-                    currentUrl = location
-                } else {
-                    return RunStatus.Success(currentUrl)
+            val response = httpClient.get(shortUrl) {
+                headers {
+                    append(HttpHeaders.UserAgent, "Mozilla/5.0")
                 }
             }
-            RunStatus.Error("リダイレクト上限超過")
+            RunStatus.Success(response.call.request.url.toString())
         } catch (e: Exception) {
             RunStatus.Error("URL 展開エラー: ${e.message}")
         }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepository.kt
@@ -1,0 +1,33 @@
+package dev.seabat.ramennote.data.repository
+
+import dev.seabat.ramennote.domain.model.RunStatus
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.http.HttpHeaders
+
+class ExpandShortUrlRepository(
+    private val httpClient: HttpClient
+) : ExpandShortUrlRepositoryContract {
+    override suspend fun expand(shortUrl: String): RunStatus<String> =
+        try {
+            var currentUrl = shortUrl
+            // maps.app.goo.gl は複数回リダイレクトする場合があるため最大10回追跡する
+            repeat(10) {
+                val response = httpClient.get(currentUrl) {
+                    headers {
+                        append(HttpHeaders.UserAgent, "Mozilla/5.0")
+                    }
+                }
+                val location = response.headers[HttpHeaders.Location]
+                if (response.status.value in 300..399 && location != null) {
+                    currentUrl = location
+                } else {
+                    return RunStatus.Success(currentUrl)
+                }
+            }
+            RunStatus.Error("リダイレクト上限超過")
+        } catch (e: Exception) {
+            RunStatus.Error("URL 展開エラー: ${e.message}")
+        }
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepositoryContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/ExpandShortUrlRepositoryContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.data.repository
+
+import dev.seabat.ramennote.domain.model.RunStatus
+
+interface ExpandShortUrlRepositoryContract {
+    suspend fun expand(shortUrl: String): RunStatus<String>
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -108,7 +108,7 @@ val useCaseModule =
         single<LoadImagePathUseCaseContract> { LoadImagePathUseCase(get()) }
         single<LoadShopListByAreaUseCaseContract> { LoadShopListByAreaUseCase(get(), get()) }
         single<LoadShopListByAreaIdUseCaseContract> { LoadShopListByAreaIdUseCase(get()) }
-        single<ResolveShopLocationUseCaseContract> { ResolveShopLocationUseCase(get(), get()) }
+        single<ResolveShopLocationUseCaseContract> { ResolveShopLocationUseCase(get(), get(), get()) }
         single<LoadShopUseCaseContract> { LoadShopUseCase(get()) }
         single<LoadRecentScheduleUseCaseContract> { LoadRecentScheduleUseCase(get(), get()) }
         single<LoadFullReportUseCaseContract> { LoadFullReportUseCase(get(), get(), get()) }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -117,29 +117,53 @@ class ResolveShopLocationUseCase(
 
     /**
      * `maps.app.goo.gl` 短縮 URL をリダイレクト展開して座標を取得する。
-     * 展開先の `/@lat,lng,zoom` 形式から座標をパースする。
-     * パース失敗時は店舗名でジオコーディングにフォールバックする。
+     *
+     * 展開先 URL を以下の優先順で処理する:
+     * 1. `/@lat,lng,zoom` 形式 → 直接パース
+     * 2. `?q=住所` 形式 → 住所で Geocoding API（店舗名より精度が高い）
+     * 3. 全て失敗 → 店舗名で Geocoding API にフォールバック
      */
     private suspend fun expandAndResolve(shop: Shop): ShopLocation? {
-        return when (val result = expandShortUrlRepository.expand(shop.mapUrl)) {
-            is RunStatus.Success -> {
-                val expandedUrl = result.data!!
-                try {
-                    // https://www.google.com/maps/place/PlaceName/@lat,lng,17z/... 形式から座標を取得
-                    val afterAt = expandedUrl.substringAfter("/@").substringBefore("/")
-                    val parts = afterAt.split(",")
-                    val lat = parts[0].toDouble()
-                    val lng = parts[1].toDouble()
-                    if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
+        val expandResult = expandShortUrlRepository.expand(shop.mapUrl)
+        if (expandResult !is RunStatus.Success) return geocodeByShopName(shop)
+        val expandedUrl = expandResult.data!!
+
+        // 1. /@lat,lng 形式を試みる
+        if (expandedUrl.contains("/@")) {
+            try {
+                val afterAt = expandedUrl.substringAfter("/@").substringBefore("/")
+                val parts = afterAt.split(",")
+                val lat = parts[0].toDouble()
+                val lng = parts[1].toDouble()
+                if (lat in 24.0..46.0 && lng in 122.0..154.0) {
                     val newMapUrl = buildMapUrl(shop, lat, lng)
                     shopsRepository.updateMapUrl(shop.id, newMapUrl)
-                    ShopLocation(shop, lat, lng)
-                } catch (_: Exception) {
-                    geocodeByShopName(shop)
+                    return ShopLocation(shop, lat, lng)
                 }
-            }
-            else -> geocodeByShopName(shop)
+            } catch (_: Exception) { /* 次の手段へ */ }
         }
+
+        // 2. q= パラメータの住所でジオコーディング
+        val address = try {
+            expandedUrl.substringAfter("?q=").substringBefore("&").decodeURLQueryComponent()
+        } catch (_: Exception) { null }
+
+        if (!address.isNullOrEmpty()) {
+            when (val geocodeResult = geocodingRepository.geocode(address)) {
+                is RunStatus.Success -> {
+                    val (lat, lng) = geocodeResult.data!!
+                    if (lat in 24.0..46.0 && lng in 122.0..154.0) {
+                        val newMapUrl = buildMapUrl(shop, lat, lng)
+                        shopsRepository.updateMapUrl(shop.id, newMapUrl)
+                        return ShopLocation(shop, lat, lng)
+                    }
+                }
+                else -> { /* 次の手段へ */ }
+            }
+        }
+
+        // 3. 店舗名でジオコーディング
+        return geocodeByShopName(shop)
     }
 
     // ピンに店舗名を表示するため q=name@lat,lng 形式を使用する

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -1,51 +1,64 @@
 package dev.seabat.ramennote.domain.usecase
 
+import dev.seabat.ramennote.data.repository.ExpandShortUrlRepositoryContract
 import dev.seabat.ramennote.data.repository.GeocodingRepositoryContract
 import dev.seabat.ramennote.data.repository.ShopsRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.domain.model.ShopLocation
 import io.ktor.http.decodeURLQueryComponent
+import io.ktor.http.encodeURLQueryComponent
 
 /**
  * ショップの mapUrl を解析して [ShopLocation] を返す UseCase。
  *
- * mapUrl の形式によって以下の3通りの処理を行う。
- * - 座標付き URL（`/maps?q=lat,lng&z=16`）: URL から座標を直接パースして返す
+ * mapUrl の形式によって以下の4通りの処理を行う。
+ * - 座標付き URL（`/maps?q=name@lat,lng&z=16`）: URL から座標を直接パースして返す
  * - 旧座標付き URL（`?q=lat,lng`）: 座標をパースし /maps?q= 形式で DB を上書きしてから返す
  * - クエリ形式（`query=...`）: Geocoding API で座標を取得し mapUrl を DB に上書きしてから返す
+ * - 短縮 URL（`maps.app.goo.gl`）: リダイレクト展開して座標を取得し DB を上書きしてから返す
  *
  * mapUrl が空または上記のいずれにも該当しない場合は `null` を返す。
  */
 class ResolveShopLocationUseCase(
     private val geocodingRepository: GeocodingRepositoryContract,
-    private val shopsRepository: ShopsRepositoryContract
+    private val shopsRepository: ShopsRepositoryContract,
+    private val expandShortUrlRepository: ExpandShortUrlRepositoryContract
 ) : ResolveShopLocationUseCaseContract {
     override suspend operator fun invoke(shop: Shop): ShopLocation? {
         if (shop.mapUrl.isEmpty()) return null
 
         return when {
-            // 座標付き URL（例: https://maps.google.com/maps?q=35.689,139.691&z=16）
+            // 座標付き URL（例: https://maps.google.com/maps?q=店舗名@35.689,139.691&z=16）
             shop.mapUrl.contains("maps.google.com/maps?q=") -> parseCoordinatesFromMapsQUrl(shop)
             // 旧座標付き URL（例: https://maps.google.com/?q=35.689,139.691）→ /maps?q= 形式へ移行
             shop.mapUrl.contains("?q=") -> parseCoordinatesFromQUrl(shop)
             // query= 形式（例: https://www.google.com/maps/search/?api=1&query=aiya+tokushima）
             shop.mapUrl.contains("query=") -> geocodeAndUpdate(shop)
+            // Google Maps 短縮 URL（例: https://maps.app.goo.gl/Wjj4TJTp6mjzLyTH8）
+            shop.mapUrl.contains("maps.app.goo.gl") -> expandAndResolve(shop)
             else -> null
         }
     }
 
     /**
-     * `/maps?q=lat,lng&z=16` 形式の URL から座標を取り出す。パース失敗時は `null` を返す。
+     * `/maps?q=name@lat,lng&z=16` 形式の URL から座標を取り出す。
+     * `name@lat,lng` と `lat,lng`（店舗名なし）の両形式に対応する。パース失敗時は `null` を返す。
      */
     private suspend fun parseCoordinatesFromMapsQUrl(shop: Shop): ShopLocation? =
         try {
             val qParam = shop.mapUrl.substringAfter("maps.google.com/maps?q=").substringBefore("&")
-            val parts = qParam.split(",")
+            // name@lat,lng 形式と lat,lng 形式の両方に対応
+            val coordsStr = if (qParam.contains("@")) qParam.substringAfterLast("@") else qParam
+            val parts = coordsStr.split(",")
             val lat = parts[0].toDouble()
             val lng = parts[1].toDouble()
             // 日本の座標範囲外はジオコーディング誤キャッシュとみなして店舗名で再ジオコーディング
             if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
+            // 店舗名なし（旧形式）は店舗名付き URL に更新する
+            if (!qParam.contains("@")) {
+                shopsRepository.updateMapUrl(shop.id, buildMapUrl(shop, lat, lng))
+            }
             ShopLocation(shop, lat, lng)
         } catch (_: Exception) {
             null
@@ -61,7 +74,7 @@ class ResolveShopLocationUseCase(
             val lat = parts[0].toDouble()
             val lng = parts[1].toDouble()
             if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
-            val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
+            val newMapUrl = buildMapUrl(shop, lat, lng)
             shopsRepository.updateMapUrl(shop.id, newMapUrl)
             ShopLocation(shop, lat, lng)
         } catch (_: Exception) {
@@ -80,7 +93,7 @@ class ResolveShopLocationUseCase(
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
                 val (lat, lng) = result.data!!
-                val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
+                val newMapUrl = buildMapUrl(shop, lat, lng)
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
             }
@@ -94,11 +107,44 @@ class ResolveShopLocationUseCase(
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
                 val (lat, lng) = result.data!!
-                val newMapUrl = "https://maps.google.com/maps?q=$lat,$lng&z=16"
+                val newMapUrl = buildMapUrl(shop, lat, lng)
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
             }
             else -> null
         }
+    }
+
+    /**
+     * `maps.app.goo.gl` 短縮 URL をリダイレクト展開して座標を取得する。
+     * 展開先の `/@lat,lng,zoom` 形式から座標をパースする。
+     * パース失敗時は店舗名でジオコーディングにフォールバックする。
+     */
+    private suspend fun expandAndResolve(shop: Shop): ShopLocation? {
+        return when (val result = expandShortUrlRepository.expand(shop.mapUrl)) {
+            is RunStatus.Success -> {
+                val expandedUrl = result.data!!
+                try {
+                    // https://www.google.com/maps/place/PlaceName/@lat,lng,17z/... 形式から座標を取得
+                    val afterAt = expandedUrl.substringAfter("/@").substringBefore("/")
+                    val parts = afterAt.split(",")
+                    val lat = parts[0].toDouble()
+                    val lng = parts[1].toDouble()
+                    if (lat !in 24.0..46.0 || lng !in 122.0..154.0) return geocodeByShopName(shop)
+                    val newMapUrl = buildMapUrl(shop, lat, lng)
+                    shopsRepository.updateMapUrl(shop.id, newMapUrl)
+                    ShopLocation(shop, lat, lng)
+                } catch (_: Exception) {
+                    geocodeByShopName(shop)
+                }
+            }
+            else -> geocodeByShopName(shop)
+        }
+    }
+
+    // ピンに店舗名を表示するため q=name@lat,lng 形式を使用する
+    private fun buildMapUrl(shop: Shop, lat: Double, lng: Double): String {
+        val encodedName = shop.name.encodeURLQueryComponent()
+        return "https://maps.google.com/maps?q=$encodedName@$lat,$lng&z=16"
     }
 }


### PR DESCRIPTION
### 概要
Google マップ上で検索・共有した短縮 URL（`maps.app.goo.gl`）が DB に格納されている場合に座標へ変換できない問題と、マップ表示時のズームレベル・ピン表示の改善を行う。

### 主な変更点

**1. mapUrl 形式の統一**
- ジオコーディング結果の保存 URL を `?q=lat,lng` から `/maps?q=名前@lat,lng&z=16` 形式に変更
- `/maps` パスにより `z=16`（ズームレベル）が有効になり適切な縮尺で表示される
- 旧形式（`?q=lat,lng`）はマップ画面を開いたタイミングで自動的に新形式へ移行

**2. Google Maps 短縮 URL の座標変換**
- `maps.app.goo.gl` 形式の URL を HTTP リダイレクト展開して座標に変換する `ExpandShortUrlRepository` を追加
- 展開先 URL の `/@lat,lng` から直接パース → 失敗時は `q=` パラメータの住所を Geocoding API でジオコーディング → 失敗時は店舗名でジオコーディング、の3段階フォールバック
- iOS の Darwin エンジン（NSURLSession）が透過的にリダイレクト処理する問題に対応するため、Ktor の `HttpRedirect` プラグインで Ktor 層にリダイレクト追跡を統一

### 影響範囲
- 新規ファイル: `ExpandShortUrlRepository.kt`、`ExpandShortUrlRepositoryContract.kt`
- 変更ファイル: `ResolveShopLocationUseCase.kt`、`DataModule.common.kt`、`DomainModule.kt`
- 破壊的変更: なし