### PR TITLE
iOS エリア画像変更後に NoteScreen の表示が更新されない不具合を修正

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "dev.seabat.ramennote"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 21
-        versionName = "1.3.0"
+        versionCode = 22
+        versionName = "1.3.1"
         manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = localProperties.getProperty("GOOGLE_MAPS_API_KEY", "")
     }
     buildFeatures {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -221,7 +221,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -241,7 +241,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ZH27S3CKAJ;
 				ENABLE_PREVIEWS = YES;
@@ -257,7 +257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.seabat.ramennote;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/iosApp/iosApp/Kmp/IosLocalStorageDataSource.swift
+++ b/iosApp/iosApp/Kmp/IosLocalStorageDataSource.swift
@@ -2,22 +2,22 @@ import sharedUI
 import Foundation
 
 class IosLocalStorageDataSource: LocalStorageDataSourceContract {
-    
+
     func __load(name: String) async throws -> KotlinByteArray? {
         do {
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
             guard let documentsPath = documentsPath else {
                 return nil
             }
-            
+
             let fileName = "\(name).png"
             let fileURL = documentsPath.appendingPathComponent(fileName)
-            
+
             // Check if file exists
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
                 return nil
             }
-            
+
             let data = try Data(contentsOf: fileURL)
             return KotlinByteArray(size: Int32(data.count)) { index in
                 KotlinByte(value: Int8(bitPattern: data[Int(index)]))
@@ -33,17 +33,17 @@ class IosLocalStorageDataSource: LocalStorageDataSourceContract {
             guard let documentsPath = documentsPath else {
                 return
             }
-            
+
             let fileName = "\(name).png"
             let fileURL = documentsPath.appendingPathComponent(fileName)
-            
+
             // Convert KotlinByteArray to Data
             var data = Data()
             for i in 0..<Int(imageBytes.size) {
                 let byte = imageBytes.get(index: Int32(i))
                 data.append(UInt8(bitPattern: byte))
             }
-            
+
             try data.write(to: fileURL)
         } catch {
             // Handle error silently or log it
@@ -65,12 +65,12 @@ class IosLocalStorageDataSource: LocalStorageDataSourceContract {
             guard let documentsPath = documentsPath else {
                 return
             }
-            
+
             let oldFileName = "\(oldName).png"
             let newFileName = "\(newName).png"
             let oldFileURL = documentsPath.appendingPathComponent(oldFileName)
             let newFileURL = documentsPath.appendingPathComponent(newFileName)
-            
+
             if FileManager.default.fileExists(atPath: oldFileURL.path) {
                 try FileManager.default.moveItem(at: oldFileURL, to: newFileURL)
             }
@@ -85,10 +85,10 @@ class IosLocalStorageDataSource: LocalStorageDataSourceContract {
             guard let documentsPath = documentsPath else {
                 return
             }
-            
+
             let fileName = "\(name).png"
             let fileURL = documentsPath.appendingPathComponent(fileName)
-            
+
             if FileManager.default.fileExists(atPath: fileURL.path) {
                 try FileManager.default.removeItem(at: fileURL)
             }
@@ -97,4 +97,3 @@ class IosLocalStorageDataSource: LocalStorageDataSourceContract {
         }
     }
 }
-

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepository.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/data/repository/UnsplashImageRepository.kt
@@ -22,24 +22,17 @@ class UnsplashImageRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 httpClient
-                    .get("$BASE_URL/search/photos") {
+                    .get("$BASE_URL/photos/random") {
                         headers {
                             append("Authorization", "Client-ID ${UnsplashConfig.ACCESS_KEY}")
                         }
                         parameter("query", query)
-                        parameter("page", 1)
-                        parameter("per_page", 1)
                         parameter("orientation", "landscape")
-                    }.body<UnsplashSearchResponse>()
+                    }.body<UnsplashPhoto>()
             }.fold(
-                onSuccess = { response: UnsplashSearchResponse ->
-                    val firstPhoto = response.results.firstOrNull()
-                    if (firstPhoto == null) {
-                        RunStatus.Error("$query の画像が見つかりませんでした。")
-                    } else {
-                        val imageResponse = httpClient.get(firstPhoto.urls.regular)
-                        RunStatus.Success(imageResponse.body<ByteArray>())
-                    }
+                onSuccess = { photo: UnsplashPhoto ->
+                    val imageResponse = httpClient.get(photo.urls.regular)
+                    RunStatus.Success(imageResponse.body<ByteArray>())
                 },
                 onFailure = { e -> RunStatus.Error(toErrorMessage(e)) }
             )
@@ -53,13 +46,6 @@ private fun toErrorMessage(e: Throwable): String =
         e.cause?.message?.contains("timeout", ignoreCase = true) == true -> "通信がタイムアウトしました"
         else -> e.message ?: "画像の取得に失敗しました"
     }
-
-@Serializable
-data class UnsplashSearchResponse(
-    val total: Int,
-    val total_pages: Int,
-    val results: List<UnsplashPhoto>
-)
 
 @Serializable
 data class UnsplashPhoto(

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/di/DomainModule.kt
@@ -24,6 +24,8 @@ import dev.seabat.ramennote.domain.usecase.FetchAiShopInfoUseCase
 import dev.seabat.ramennote.domain.usecase.FetchAiShopUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCase
 import dev.seabat.ramennote.domain.usecase.FetchAndSaveUnsplashImageUseCaseContract
+import dev.seabat.ramennote.domain.usecase.FetchUnsplashImageUseCase
+import dev.seabat.ramennote.domain.usecase.FetchUnsplashImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCase
 import dev.seabat.ramennote.domain.usecase.FetchPlaceHolderImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.InquiryAppVersionUseCase
@@ -101,6 +103,7 @@ val useCaseModule =
         single<FetchAiShopUseCaseContract> { FetchAiShopInfoUseCase(get(), get()) }
         single<FetchPlaceHolderImageUseCaseContract> { FetchPlaceHolderImageUseCase(get(), get()) }
         single<FetchAndSaveUnsplashImageUseCaseContract> { FetchAndSaveUnsplashImageUseCase(get(), get(), get()) }
+        single<FetchUnsplashImageUseCaseContract> { FetchUnsplashImageUseCase(get(), get(), get()) }
         single<InquiryAppVersionUseCaseContract> { InquiryAppVersionUseCase(get()) }
         single<LoadAreasUseCaseContract> { LoadAreasUseCase(get()) }
         single<LoadAreaImageUseCaseContract> { LoadAreaImageUseCase(get(), get()) }

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchUnsplashImageUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchUnsplashImageUseCase.kt
@@ -1,0 +1,40 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.data.repository.AreasRepositoryContract
+import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
+import dev.seabat.ramennote.data.repository.UnsplashImageRepositoryContract
+import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.util.createTodayLocalDate
+
+/**
+ * Unsplash から画像を取得する（ローカル保存は行わない）
+ *
+ * ローカル画像が存在しない場合は制限なく取得する。
+ * ローカル画像が存在する場合は updatedDate が今日より前であれば取得を許可し、
+ * 今日と同じ場合はエラーを返す。
+ */
+class FetchUnsplashImageUseCase(
+    private val unsplashImageRepository: UnsplashImageRepositoryContract,
+    private val localAreaImageRepository: LocalImageRepositoryContract,
+    private val areasRepository: AreasRepositoryContract
+) : FetchUnsplashImageUseCaseContract {
+    override suspend operator fun invoke(areaName: String): RunStatus<ByteArray> {
+        when (val runStatus = localAreaImageRepository.load(areaName)) {
+            is RunStatus.Error if (runStatus.data == null) -> {
+                return unsplashImageRepository.fetch(areaName)
+            }
+            else -> {}
+        }
+
+        val areaData =
+            areasRepository.load(areaName)
+                ?: return RunStatus.Error("エリアが登録されていません")
+
+        val today = createTodayLocalDate()
+        return if (areaData.updatedDate < today) {
+            unsplashImageRepository.fetch(areaName)
+        } else {
+            RunStatus.Error("本日は画像を変更できません。明日もう一度お試しください。")
+        }
+    }
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchUnsplashImageUseCaseContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/FetchUnsplashImageUseCaseContract.kt
@@ -1,0 +1,7 @@
+package dev.seabat.ramennote.domain.usecase
+
+import dev.seabat.ramennote.domain.model.RunStatus
+
+interface FetchUnsplashImageUseCaseContract {
+    suspend operator fun invoke(areaName: String): RunStatus<ByteArray>
+}

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCase.kt
@@ -3,12 +3,13 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.data.repository.AreasRepositoryContract
 import dev.seabat.ramennote.data.repository.LocalImageRepositoryContract
 import dev.seabat.ramennote.domain.model.RunStatus
+import dev.seabat.ramennote.domain.util.createTodayLocalDate
 
 class UpdateAreaUseCase(
     private val areasRepository: AreasRepositoryContract,
     private val localAreaImageRepository: LocalImageRepositoryContract
 ) : UpdateAreaUseCaseContract {
-    override suspend fun invoke(areaId: Int, newName: String): RunStatus<String> {
+    override suspend fun invoke(areaId: Int, newName: String, byteArray: ByteArray?): RunStatus<String> {
         val oldName =
             areasRepository.loadByAreaId(areaId)?.name
                 ?: return RunStatus.Error("エリアが見つかりません")
@@ -21,10 +22,20 @@ class UpdateAreaUseCase(
         val result = areasRepository.edit(oldName, newName)
         return if (result is RunStatus.Success) {
             try {
-                // 画像名のリネーム
-                localAreaImageRepository.rename(oldName, newName)
-
-                // areaId が外部キーのため、エリア名変更時のShop更新は不要
+                if (byteArray != null) {
+                    // 新画像を newName で保存し updatedDate を更新
+                    localAreaImageRepository.save(byteArray, newName)
+                    areasRepository.load(newName)?.let { area ->
+                        areasRepository.edit(area.copy(updatedDate = createTodayLocalDate()))
+                    }
+                    // 名前が変わった場合は旧ファイルを削除
+                    if (oldName != newName) {
+                        localAreaImageRepository.delete(oldName)
+                    }
+                } else if (oldName != newName) {
+                    // 画像変更なし・名前変更あり: ファイルをリネーム
+                    localAreaImageRepository.rename(oldName, newName)
+                }
                 RunStatus.Success("")
             } catch (e: Exception) {
                 RunStatus.Error("${e.message}")

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCaseContract.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/UpdateAreaUseCaseContract.kt
@@ -3,5 +3,5 @@ package dev.seabat.ramennote.domain.usecase
 import dev.seabat.ramennote.domain.model.RunStatus
 
 interface UpdateAreaUseCaseContract {
-    suspend operator fun invoke(areaId: Int, newName: String): RunStatus<String>
+    suspend operator fun invoke(areaId: Int, newName: String, byteArray: ByteArray? = null): RunStatus<String>
 }

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/navigation/MainNavigation.kt
@@ -287,6 +287,9 @@ fun MainNavigation() {
     // HistoryScreenに遷移する際のareaIdを管理するState
     var areaIdParam by remember { mutableStateOf<Int?>(null) }
 
+    // NoteScreen のエリア一覧再取得トリガー（エリア関連の子画面が完了したときにインクリメント）
+    var noteRefreshKey by remember { mutableStateOf(0) }
+
     val tabScreens =
         listOf(
             Screen.Home,
@@ -444,6 +447,7 @@ fun MainNavigation() {
                     }
                     composable<Screen.Note> {
                         NoteScreen(
+                            refreshKey = noteRefreshKey,
                             goToAreaShopList = { areaName ->
                                 navController.navigate(Screen.AreaShopList(areaName))
                             },
@@ -516,7 +520,10 @@ fun MainNavigation() {
                     composable<Screen.AddArea> {
                         AddAreaScreen(
                             onBackClick = { navController.popBackStack() },
-                            onCompleted = { navController.popBackStack() }
+                            onCompleted = {
+                                noteRefreshKey++
+                                navController.popBackStack()
+                            }
                         )
                     }
                     composable<Screen.EditArea> { backStackEntry ->
@@ -524,13 +531,19 @@ fun MainNavigation() {
                         EditAreaScreen(
                             areaId = screen.areaId,
                             onBackClick = { navController.popBackStack() },
-                            onCompleted = { navController.popBackStack() }
+                            onCompleted = {
+                                noteRefreshKey++
+                                navController.popBackStack()
+                            }
                         )
                     }
                     composable<Screen.EditAreaSort> {
                         EditAreaSortScreen(
                             onBackClick = { navController.popBackStack() },
-                            onCompleted = { navController.popBackStack() }
+                            onCompleted = {
+                                noteRefreshKey++
+                                navController.popBackStack()
+                            }
                         )
                     }
                     composable<Screen.Shop> { backStackEntry ->

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -51,7 +51,6 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.AppBar
-import dev.seabat.ramennote.ui.components.rememberLifecycleState
 import dev.seabat.ramennote.ui.components.banner.HintBanner
 import dev.seabat.ramennote.ui.components.button.ActionButton
 import dev.seabat.ramennote.ui.components.button.AddFab
@@ -80,6 +79,7 @@ import ramennote.sharedui.generated.resources.sort_24px
 
 @Composable
 fun NoteScreen(
+    refreshKey: Int = 0,
     initialSearchText: String = "",
     goToAreaShopList: (String) -> Unit = {},
     goToAddArea: () -> Unit = {},
@@ -98,6 +98,7 @@ fun NoteScreen(
     ) {
         ScreenBar()
         MainContent(
+            refreshKey = refreshKey,
             viewModel = viewModel,
             onAreaClick = goToAreaShopList,
             onAddAreaClick = goToAddArea,
@@ -119,6 +120,7 @@ private fun ScreenBar() {
 
 @Composable
 private fun MainContent(
+    refreshKey: Int = 0,
     viewModel: NoteViewModelContract,
     onAreaClick: (String) -> Unit = {},
     onAddAreaClick: () -> Unit = {},
@@ -167,11 +169,8 @@ private fun MainContent(
             var isSearchResultVisible by remember { mutableStateOf(initialSearchText.isNotEmpty()) }
             var searchText by remember { mutableStateOf(initialSearchText) }
 
-            val lifecycleState by rememberLifecycleState()
-            LaunchedEffect(lifecycleState.isResumed) {
-                if (lifecycleState.isResumed) {
-                    viewModel.fetchAreas()
-                }
+            LaunchedEffect(refreshKey) {
+                viewModel.fetchAreas()
             }
 
             LaunchedEffect(Unit) {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -261,7 +261,7 @@ private fun MainContent(
                                 AreaItem(
                                     areaName = area.name,
                                     imagePath = area.imagePath,
-                                    imageKey = area.updatedDate.toString(),
+                                    imageKey = refreshKey.toString(),
                                     itemCount = "${area.count}${stringResource(Res.string.note_item_count)}",
                                     onClick = { onAreaClick(area.name) },
                                     onLongClick = { onAreaLongClick(area.areaId) },

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -47,8 +47,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
 import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.AppBar
+import dev.seabat.ramennote.ui.components.rememberLifecycleState
 import dev.seabat.ramennote.ui.components.banner.HintBanner
 import dev.seabat.ramennote.ui.components.button.ActionButton
 import dev.seabat.ramennote.ui.components.button.AddFab
@@ -164,8 +167,14 @@ private fun MainContent(
             var isSearchResultVisible by remember { mutableStateOf(initialSearchText.isNotEmpty()) }
             var searchText by remember { mutableStateOf(initialSearchText) }
 
+            val lifecycleState by rememberLifecycleState()
+            LaunchedEffect(lifecycleState.isResumed) {
+                if (lifecycleState.isResumed) {
+                    viewModel.fetchAreas()
+                }
+            }
+
             LaunchedEffect(Unit) {
-                viewModel.fetchAreas()
                 if (searchText.isNotEmpty()) {
                     viewModel.searchShops(searchText)
                 }
@@ -253,6 +262,7 @@ private fun MainContent(
                                 AreaItem(
                                     areaName = area.name,
                                     imagePath = area.imagePath,
+                                    imageKey = area.updatedDate.toString(),
                                     itemCount = "${area.count}${stringResource(Res.string.note_item_count)}",
                                     onClick = { onAreaClick(area.name) },
                                     onLongClick = { onAreaLongClick(area.areaId) },
@@ -323,6 +333,7 @@ private fun SortButton(
 private fun AreaItem(
     areaName: String,
     imagePath: String? = null,
+    imageKey: String? = null,
     itemCount: String,
     onClick: () -> Unit,
     onLongClick: () -> Unit = {},
@@ -348,7 +359,10 @@ private fun AreaItem(
             // 背景画像
             if (imagePath != null) {
                 AsyncImage(
-                    model = imagePath,
+                    model = ImageRequest.Builder(LocalPlatformContext.current)
+                        .data(imagePath)
+                        .memoryCacheKey("$imagePath#$imageKey")
+                        .build(),
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -222,7 +222,9 @@ fun EditStatus(
 ) {
     when (editStatus) {
         is RunStatus.Success -> {
-            onCompleted()
+            LaunchedEffect(editStatus) {
+                onCompleted()
+            }
         }
         is RunStatus.Error -> {
             AppAlert(
@@ -244,7 +246,9 @@ fun DeleteStatus(
 ) {
     when (deleteStatus) {
         is RunStatus.Success -> {
-            onCompleted()
+            LaunchedEffect(deleteStatus) {
+                onCompleted()
+            }
         }
         is RunStatus.Error -> {
             AppAlert(

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.seabat.ramennote.domain.model.RunStatus
 import dev.seabat.ramennote.domain.usecase.DeleteAreaUseCaseContract
+import dev.seabat.ramennote.domain.usecase.FetchUnsplashImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadAreaImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.LoadAreasUseCaseContract
-import dev.seabat.ramennote.domain.usecase.UpdateAreaImageUseCaseContract
 import dev.seabat.ramennote.domain.usecase.UpdateAreaUseCaseContract
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 class EditAreaViewModel(
     private val deleteAreaUseCase: DeleteAreaUseCaseContract,
     private val updateAreaUseCase: UpdateAreaUseCaseContract,
-    private val updateAreaImageUseCase: UpdateAreaImageUseCaseContract,
+    private val fetchUnsplashImageUseCase: FetchUnsplashImageUseCaseContract,
     private val loadAreaImageUseCase: LoadAreaImageUseCaseContract,
     private val loadAreasUseCase: LoadAreasUseCaseContract
 ) : ViewModel(),
@@ -36,12 +36,16 @@ class EditAreaViewModel(
     private val _areaName: MutableStateFlow<String> = MutableStateFlow("")
     override val areaName: StateFlow<String> = _areaName.asStateFlow()
 
+    // 新たに取得した画像バイト（null = 画像変更なし）
+    private var newImageBytes: ByteArray? = null
+
     override fun editArea(areaId: Int, newAreaName: String) {
         viewModelScope.launch {
             _editState.value = RunStatus.Loading()
-            _editState.value = updateAreaUseCase(areaId, newAreaName)
+            _editState.value = updateAreaUseCase(areaId, newAreaName, newImageBytes)
             if (_editState.value is RunStatus.Success) {
                 _areaName.value = newAreaName
+                newImageBytes = null
             }
         }
     }
@@ -56,7 +60,11 @@ class EditAreaViewModel(
     override fun fetchNewImage(areaName: String) {
         viewModelScope.launch {
             _imageState.value = RunStatus.Loading()
-            _imageState.value = updateAreaImageUseCase(areaName)
+            val result = fetchUnsplashImageUseCase(areaName)
+            _imageState.value = result
+            if (result is RunStatus.Success) {
+                newImageBytes = result.data
+            }
         }
     }
 
@@ -76,6 +84,7 @@ class EditAreaViewModel(
     }
 
     override fun resetImageState() {
+        newImageBytes = null
         _imageState.value = RunStatus.Idle()
     }
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaViewModel.kt
@@ -39,6 +39,9 @@ class EditAreaViewModel(
     // 新たに取得した画像バイト（null = 画像変更なし）
     private var newImageBytes: ByteArray? = null
 
+    // 現在表示中の画像バイト（エラー後に復元するため保持）
+    private var displayedImageBytes: ByteArray? = null
+
     override fun editArea(areaId: Int, newAreaName: String) {
         viewModelScope.launch {
             _editState.value = RunStatus.Loading()
@@ -64,6 +67,7 @@ class EditAreaViewModel(
             _imageState.value = result
             if (result is RunStatus.Success) {
                 newImageBytes = result.data
+                displayedImageBytes = result.data
             }
         }
     }
@@ -79,13 +83,16 @@ class EditAreaViewModel(
     override fun loadImage(areaId: Int) {
         viewModelScope.launch {
             _imageState.value = RunStatus.Loading()
-            _imageState.value = loadAreaImageUseCase(areaId)
+            val result = loadAreaImageUseCase(areaId)
+            _imageState.value = result
+            if (result is RunStatus.Success) {
+                displayedImageBytes = result.data
+            }
         }
     }
 
     override fun resetImageState() {
-        newImageBytes = null
-        _imageState.value = RunStatus.Idle()
+        _imageState.value = displayedImageBytes?.let { RunStatus.Success(it) } ?: RunStatus.Idle()
     }
 
     override fun resetEditState() {

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/LifecycleObserver.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/LifecycleObserver.ios.kt
@@ -5,40 +5,35 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import kotlinx.cinterop.ExperimentalForeignApi
-import platform.Foundation.NSNotificationCenter
-import platform.UIKit.UIApplicationDidBecomeActiveNotification
-import platform.UIKit.UIApplicationWillResignActiveNotification
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import dev.seabat.ramennote.domain.util.logd
 
-@OptIn(ExperimentalForeignApi::class)
 @Composable
 actual fun rememberLifecycleState(): State<LifecycleState> {
-    val lifecycleState = remember { mutableStateOf(LifecycleState(isResumed = true)) } // デフォルトはtrue（アプリ起動時はフォアグラウンド）
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleState =
+        remember {
+            mutableStateOf(
+                LifecycleState(
+                    isResumed =
+                        lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+                )
+            )
+        }
 
-    DisposableEffect(Unit) {
-        val notificationCenter = NSNotificationCenter.defaultCenter
-
-        val becomeActiveObserver =
-            notificationCenter.addObserverForName(
-                name = UIApplicationDidBecomeActiveNotification,
-                `object` = null,
-                queue = null
-            ) { _ ->
-                lifecycleState.value = lifecycleState.value.copy(isResumed = true)
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                logd(message = "event: $event")
+                lifecycleState.value = lifecycleState.value.copy(isResumed = event == Lifecycle.Event.ON_RESUME)
             }
-
-        val resignActiveObserver =
-            notificationCenter.addObserverForName(
-                name = UIApplicationWillResignActiveNotification,
-                `object` = null,
-                queue = null
-            ) { _ ->
-                lifecycleState.value = lifecycleState.value.copy(isResumed = false)
-            }
-
+        logd(message = "start observe lifecycle")
+        lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
-            notificationCenter.removeObserver(becomeActiveObserver)
-            notificationCenter.removeObserver(resignActiveObserver)
+            logd(message = "stop observe lifecycle")
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/LifecycleObserver.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/components/LifecycleObserver.ios.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import dev.seabat.ramennote.domain.util.logd
 
 @Composable
 actual fun rememberLifecycleState(): State<LifecycleState> {
@@ -26,13 +25,10 @@ actual fun rememberLifecycleState(): State<LifecycleState> {
     DisposableEffect(lifecycleOwner) {
         val observer =
             LifecycleEventObserver { _, event ->
-                logd(message = "event: $event")
                 lifecycleState.value = lifecycleState.value.copy(isResumed = event == Lifecycle.Event.ON_RESUME)
             }
-        logd(message = "start observe lifecycle")
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
-            logd(message = "stop observe lifecycle")
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }


### PR DESCRIPTION
### 概要
EditAreaScreen でエリア画像を変更して「変更する」ボタンを押しても、NoteScreen に戻った際に新しい画像が表示されない不具合を修正した。あわせて画像取得・保存フローのリファクタリングと関連バグの修正を行った。

### 主な変更点

**1. NoteScreen の画像キャッシュ無効化**
- Coil のメモリキャッシュキーを `updatedDate`（日付精度）から `refreshKey`（編集ごとにインクリメント）に変更
- EditAreaScreen から戻るたびにキャッシュキーが変わり、ディスクから新画像を読み込む

**2. NoteScreen のデータ再取得**
- `rememberLifecycleState()` による再取得を廃止し、`refreshKey` ベースの明示的なリフレッシュに変更
- AddArea / EditArea / EditAreaSort の完了時に `noteRefreshKey` をインクリメントして確実にエリア一覧を再取得

**3. 画像変更フローのリファクタリング**
- 「画像を変更する」ボタンは Unsplash から取得するのみ（保存しない）
- 「変更する」ボタン押下時に初めて画像をディスクに保存・`updatedDate` を更新
- `FetchUnsplashImageUseCase` を新規追加

**4. 関連バグ修正**
- `EditStatus` / `DeleteStatus` で `onCompleted()` を Composable 本体内で直接呼び出していたため、recompose のたびに `popBackStack()` が繰り返され NoteScreen が真っ白になるバグを修正（`LaunchedEffect` に移動）
- 画像取得エラー時に EditAreaScreen の既存画像が消えるバグを修正
- Unsplash API を `/search/photos`（常に同じ画像）から `/photos/random`（毎回ランダム）に変更

### 影響範囲
- 新規ファイル: `FetchUnsplashImageUseCase.kt`・`FetchUnsplashImageUseCaseContract.kt`
- 変更ファイル: `EditAreaViewModel.kt`・`UpdateAreaUseCase.kt`・`NoteScreen.kt`・`MainNavigation.kt`・`EditAreaScreen.kt`・`LifecycleObserver.ios.kt`・`UnsplashImageRepository.kt`
- 破壊的変更: なし