### PR TITLE
NavGraph プラグイン導入と @Preview import の androidx 移行

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ firebase-bom = "34.12.0"
 googleService = "4.4.4"
 firebaseCrashlyticsPlugin = "3.0.7"
 mapsCompose = "6.4.1"
+skie = "0.10.12"
+navgraph = "0.1.1"
 
 
 [libraries]
@@ -89,3 +91,5 @@ room = { id = "androidx.room", version.ref = "room" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 googleService = { id = "com.google.gms.google-services", version.ref = "googleService" }
 firebaseCrashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
+touchlab-skie = { id = "co.touchlab.skie", version.ref = "skie" }
+skydoves-navgraph = { id = "com.github.skydoves.navgraph", version.ref = "navgraph" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ googleService = "4.4.4"
 firebaseCrashlyticsPlugin = "3.0.7"
 mapsCompose = "6.4.1"
 skie = "0.10.12"
-navgraph = "0.1.1"
+navgraph = "0.2.0"
 
 
 [libraries]

--- a/sharedUI/build.gradle.kts
+++ b/sharedUI/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.kotlin.serialization)
-    id("co.touchlab.skie") version "0.10.12"
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.touchlab.skie)
+    alias(libs.plugins.skydoves.navgraph)
 }
 
 kotlin {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/App.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/App.kt
@@ -3,7 +3,7 @@ package dev.seabat.ramennote.ui
 import androidx.compose.runtime.Composable
 import dev.seabat.ramennote.ui.navigation.MainNavigation
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppBar.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/AppBar.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/StarIcon.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/StarIcon.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.kid_star_24px_empty
 import ramennote.sharedui.generated.resources.kid_star_24px_fill

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/banner/HintBanner.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/banner/HintBanner.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun HintBanner(isVisible: Boolean, text: String = "Network error occurred") {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ActionButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ActionButton.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.ramen_dining_24px
 import ramennote.sharedui.generated.resources.shop_menu_report_button

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddReportButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/AddReportButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.ramen_dining_24px
 import ramennote.sharedui.generated.resources.shop_menu_report_button

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/EditShopButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/EditShopButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.edit_24px
 import ramennote.sharedui.generated.resources.shop_menu_edit_button

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ReportListButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.ramen_dining_24px
 import ramennote.sharedui.generated.resources.shop_menu_history_button

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ScheduleButton.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/button/ScheduleButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.event_note_24px
 import ramennote.sharedui.generated.resources.shop_menu_schedule_add_button

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/chart/StackedBarChart.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/chart/StackedBarChart.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.domain.model.MonthlyReportCount
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.home_no_recent_report
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/SelectShopDialog.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/components/dialog/SelectShopDialog.kt
@@ -36,7 +36,7 @@ import dev.seabat.ramennote.ui.screens.history.SelectShopViewModel
 import dev.seabat.ramennote.ui.screens.history.SelectShopViewModelContract
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.select_shop_dialog_area_label

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/MenuItem.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/MenuItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun MenuItem(

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/RamenField.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/RamenField.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_shop_menu_name_label
 import ramennote.sharedui.generated.resources.add_shop_no_image

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ReportCard.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ReportCard.kt
@@ -41,7 +41,7 @@ import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import dev.seabat.ramennote.ui.util.dayOfWeekJp
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.ios_share_24px
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDetailItem.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDetailItem.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_no_data_label
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopDropdownField.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.components.dropdown.DropdownAnchorField
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopInputField.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopInputField.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.delete_24px
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopItem.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopItem.kt
@@ -19,7 +19,7 @@ import dev.seabat.ramennote.domain.model.Shop
 import dev.seabat.ramennote.ui.components.ShopStarIcon
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.favorite_disabled
 import ramennote.sharedui.generated.resources.favorite_enabled

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopMultilineInputField.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/ShopMultilineInputField.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.delete_24px
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/StarRating.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/componens/StarRating.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.components.ReportStarIcon
 import dev.seabat.ramennote.ui.components.ShopStarIcon
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_evaluation_label
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -48,6 +48,10 @@ import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.history_no_data
@@ -59,6 +63,9 @@ import ramennote.sharedui.generated.resources.note_notification
 import ramennote.sharedui.generated.resources.screen_history_title
 import ramennote.sharedui.generated.resources.select_shop_dialog_write_report_button
 
+@NavDestination(route = Screen.History::class)
+@NavEdge(to = Screen.EditReport::class, label = "レポート編集へ")
+@NavEdge(to = Screen.Report::class, label = "レポート追加へ")
 @Composable
 fun HistoryScreen(
     reportId: Int? = null,
@@ -491,6 +498,7 @@ private fun MenuWithSearchTextPreview() {
     }
 }
 
+@NavPreview(Screen.History::class, primary = true)
 @Preview
 @Composable
 fun HistoryScreenPreview() {
@@ -499,6 +507,7 @@ fun HistoryScreenPreview() {
     }
 }
 
+@NavPreview(Screen.History::class, primary = false)
 @Preview
 @Composable
 fun HistoryScreenForSearchWithNoHitPreview() {
@@ -510,6 +519,7 @@ fun HistoryScreenForSearchWithNoHitPreview() {
     }
 }
 
+@NavPreview(Screen.History::class, primary = false)
 @Preview
 @Composable
 fun HistoryScreenForSearchWithHitsPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/HistoryScreen.kt
@@ -47,7 +47,7 @@ import dev.seabat.ramennote.ui.share.createRememberedXShareLauncher
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
@@ -45,7 +45,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/addreport/AddReportScreen.kt
@@ -46,6 +46,10 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.report_header
@@ -55,6 +59,8 @@ import ramennote.sharedui.generated.resources.report_run
 import ramennote.sharedui.generated.resources.report_shop_name
 import kotlin.time.Instant
 
+@NavDestination(route = Screen.Report::class)
+@NavEdge(to = Screen.History::class, label = "履歴へ")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddReportScreen(
@@ -261,6 +267,7 @@ fun ReportStatus(
     }
 }
 
+@NavPreview(route = Screen.Report::class, primary = true)
 @Preview
 @Composable
 fun ReportScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
@@ -39,7 +39,7 @@ import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/history/editreport/EditReportScreen.kt
@@ -40,6 +40,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.editreport_delete_button
@@ -58,6 +61,7 @@ private sealed interface ErrorDialogType {
     ) : ErrorDialogType
 }
 
+@NavDestination(route = Screen.EditReport::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditReportScreen(
@@ -305,6 +309,7 @@ fun BottomButtons(
     }
 }
 
+@NavPreview(route = Screen.EditReport::class, primary = true)
 @Preview
 @Composable
 fun EditReportScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/FavoriteShopMenuDialog.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/FavoriteShopMenuDialog.kt
@@ -14,7 +14,7 @@ import dev.seabat.ramennote.ui.screens.componens.MenuItem
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.book_5_24px
 import ramennote.sharedui.generated.resources.event_note_24px

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -86,6 +86,11 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavGraphRoot
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_schedule_error_past_date_message
@@ -132,6 +137,11 @@ private sealed interface DialogState {
     object CompleteAddSchedule : DialogState
 }
 
+@NavGraphRoot
+@NavDestination(route = Screen.Home::class)
+@NavEdge(to = Screen.Shop::class, label = "店舗詳細へ")
+@NavEdge(to = Screen.Report::class, label = "レポート追加へ")
+@NavEdge(to = Screen.History::class, label = "履歴へ")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
@@ -1041,5 +1051,14 @@ fun YearlyReportChartEmptyPreview() {
             // データがない場合のプレビュー
             YearlyReportChart(emptyList())
         }
+    }
+}
+
+@NavPreview(Screen.Home::class, primary = true)
+@Preview
+@Composable
+fun HomeScreenPreview() {
+    RamenNoteTheme {
+        HomeScreen(viewModel = MockHomeViewModel())
     }
 }

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/HomeScreen.kt
@@ -85,7 +85,7 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavGraphRoot

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/ScheduleMenuDialog.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/home/ScheduleMenuDialog.kt
@@ -15,7 +15,7 @@ import dev.seabat.ramennote.ui.screens.componens.MenuItem
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.book_5_24px
 import ramennote.sharedui.generated.resources.globe_24px

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/NoteScreen.kt
@@ -63,6 +63,10 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.location_on_24px
@@ -77,6 +81,14 @@ import ramennote.sharedui.generated.resources.note_sort
 import ramennote.sharedui.generated.resources.screen_note_title
 import ramennote.sharedui.generated.resources.sort_24px
 
+@NavDestination(route = Screen.Note::class)
+@NavEdge(to = Screen.AreaShopList::class, label = "エリア店舗リストへ")
+@NavEdge(to = Screen.AddArea::class, label = "エリア追加へ")
+@NavEdge(to = Screen.EditArea::class, label = "エリア編集へ")
+@NavEdge(to = Screen.EditAreaSort::class, label = "エリア並べ替えへ")
+@NavEdge(to = Screen.Shop::class, label = "店舗詳細へ")
+@NavEdge(to = Screen.History::class, label = "履歴（エリアフィルタ）へ")
+@NavEdge(to = Screen.ShopsLocation::class, label = "マップへ")
 @Composable
 fun NoteScreen(
     refreshKey: Int = 0,
@@ -437,6 +449,7 @@ fun AreaItemPreview() {
     }
 }
 
+@NavPreview(route = Screen.Note::class, primary = true)
 @Preview
 @Composable
 fun NoteScreenForAreaPreview() {
@@ -449,6 +462,7 @@ fun NoteScreenForAreaPreview() {
     }
 }
 
+@NavPreview(route = Screen.Note::class, primary = false)
 @Preview
 @Composable
 fun NoteScreenForSearchPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
@@ -34,7 +34,7 @@ import dev.seabat.ramennote.ui.components.alert.AppAlert
 import dev.seabat.ramennote.ui.components.button.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addarea/AddAreaScreen.kt
@@ -35,6 +35,9 @@ import dev.seabat.ramennote.ui.components.button.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_shop_add_button
@@ -42,6 +45,7 @@ import ramennote.sharedui.generated.resources.add_shop_area_description
 import ramennote.sharedui.generated.resources.add_shop_area_input
 import ramennote.sharedui.generated.resources.add_shop_area_title
 
+@NavDestination(route = Screen.AddArea::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddAreaScreen(
@@ -139,6 +143,7 @@ fun AddStatus(
     }
 }
 
+@NavPreview(Screen.AddArea::class, primary = true)
 @Preview
 @Composable
 fun AddAreaScreenView() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -53,6 +53,9 @@ import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_category_label
@@ -66,6 +69,7 @@ import ramennote.sharedui.generated.resources.add_station_label
 import ramennote.sharedui.generated.resources.add_web_site_label
 import kotlin.time.Clock
 
+@NavDestination(route = Screen.AddShop::class)
 @Composable
 fun AddShopScreen(
     areaName: String,
@@ -420,6 +424,7 @@ private fun ShopAiInfoState(
     }
 }
 
+@NavPreview(route = Screen.AddShop::class, primary = true)
 @Preview
 @Composable
 fun AddShopScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/addshop/AddShopScreen.kt
@@ -52,7 +52,7 @@ import dev.seabat.ramennote.ui.screens.note.categoryList
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -39,6 +39,9 @@ import dev.seabat.ramennote.ui.components.button.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.editarea_change_image_button
@@ -48,6 +51,7 @@ import ramennote.sharedui.generated.resources.editarea_edit_button
 import ramennote.sharedui.generated.resources.editarea_image_load_error
 import ramennote.sharedui.generated.resources.editarea_title
 
+@NavDestination(route = Screen.EditArea::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditAreaScreen(
@@ -263,6 +267,7 @@ fun DeleteStatus(
     }
 }
 
+@NavPreview(Screen.EditArea::class, primary = true)
 @Preview
 @Composable
 fun EditAreaScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editarea/EditAreaScreen.kt
@@ -38,7 +38,7 @@ import dev.seabat.ramennote.ui.components.alert.AppTwoButtonAlert
 import dev.seabat.ramennote.ui.components.button.MaxWidthButton
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editareasort/EditAreaSortScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editareasort/EditAreaSortScreen.kt
@@ -45,7 +45,7 @@ import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editareasort/EditAreaSortScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editareasort/EditAreaSortScreen.kt
@@ -46,6 +46,9 @@ import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_circle_24px
@@ -54,6 +57,7 @@ import ramennote.sharedui.generated.resources.editarea_edit_button
 import ramennote.sharedui.generated.resources.editareasort_description
 import ramennote.sharedui.generated.resources.editareasort_title
 
+@NavDestination(route = Screen.EditAreaSort::class)
 @Composable
 fun EditAreaSortScreen(
     onBackClick: () -> Unit,
@@ -253,6 +257,7 @@ private fun EditAreasStatus(
     }
 }
 
+@NavPreview(Screen.EditAreaSort::class, primary = true)
 @Preview
 @Composable
 fun EditAreaSortScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
@@ -39,6 +39,10 @@ import dev.seabat.ramennote.ui.screens.note.categoryList
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_map_label
@@ -63,6 +67,8 @@ private sealed interface ErrorDialogType {
     ) : ErrorDialogType
 }
 
+@NavDestination(route = Screen.EditShop::class)
+@NavEdge(to = Screen.AreaShopList::class, label = "エリア店舗リストへ")
 @Composable
 fun EditShopScreen(
     shop: Shop,
@@ -308,6 +314,7 @@ fun EditShopScreen(
     }
 }
 
+@NavPreview(route = Screen.EditShop::class, primary = true)
 @Preview
 @Composable
 fun EditShopScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/editshop/EditShopScreen.kt
@@ -38,7 +38,7 @@ import dev.seabat.ramennote.ui.screens.componens.ShopStarRatingItem
 import dev.seabat.ramennote.ui.screens.note.categoryList
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/SearchInputField.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/SearchInputField.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.delete_24px
 

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
@@ -58,6 +58,10 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_category_label
@@ -76,6 +80,10 @@ import ramennote.sharedui.generated.resources.schedule_picker_label
 import ramennote.sharedui.generated.resources.shop_map_label
 import kotlin.time.Instant
 
+@NavDestination(route = Screen.Shop::class)
+@NavEdge(to = Screen.EditShop::class, label = "店舗編集へ")
+@NavEdge(to = Screen.Report::class, label = "レポート追加へ")
+@NavEdge(to = Screen.History::class, label = "履歴へ")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ShopScreen(
@@ -522,6 +530,7 @@ private fun datePickerOnClickHandler(
     }
 }
 
+@NavPreview(route = Screen.Shop::class, primary = true)
 @Preview
 @Composable
 fun ShopScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shop/ShopScreen.kt
@@ -57,7 +57,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
@@ -24,7 +24,7 @@ import dev.seabat.ramennote.ui.components.button.AddFab
 import dev.seabat.ramennote.ui.screens.componens.ShopItem
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shoplist/AreaShopListScreen.kt
@@ -25,10 +25,17 @@ import dev.seabat.ramennote.ui.screens.componens.ShopItem
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.shoplist_no_data
 
+@NavDestination(route = Screen.AreaShopList::class)
+@NavEdge(to = Screen.Shop::class, label = "店舗詳細へ")
+@NavEdge(to = Screen.AddShop::class, label = "店舗追加へ")
 @Composable
 fun AreaShopListScreen(
     areaName: String,
@@ -121,6 +128,7 @@ private fun AreaShopListMainContent(
     }
 }
 
+@NavPreview(Screen.AreaShopList::class, primary = true)
 @Preview
 @Composable
 fun DetailScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
@@ -14,8 +14,14 @@ import dev.seabat.ramennote.ui.components.AppProgressBar
 import dev.seabat.ramennote.ui.components.ShopsMap
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 
+@NavDestination(route = Screen.ShopsLocation::class)
+@NavEdge(to = Screen.Shop::class, label = "店舗詳細へ")
 @Composable
 fun ShopsLocationScreen(
     areaId: Int,
@@ -51,6 +57,7 @@ fun ShopsLocationScreen(
     }
 }
 
+@NavPreview(route = Screen.ShopsLocation::class, primary = true)
 @Preview
 @Composable
 private fun ShopsLocationScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/note/shopslocation/ShopsLocationScreen.kt
@@ -13,7 +13,7 @@ import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.components.AppProgressBar
 import dev.seabat.ramennote.ui.components.ShopsMap
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -47,7 +47,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavEdge
 import com.github.skydoves.navgraph.annotations.NavPreview

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/schedule/ScheduleScreen.kt
@@ -48,6 +48,10 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavEdge
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.add_schedule_error_past_date_message
@@ -81,6 +85,9 @@ private sealed interface DialogState {
     ) : DialogState
 }
 
+@NavDestination(route = Screen.Schedule::class)
+@NavEdge(to = Screen.Report::class, label = "レポート追加へ")
+@NavEdge(to = Screen.Shop::class, label = "店舗詳細へ")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ScheduleScreen(
@@ -450,6 +457,7 @@ private fun datePickerOnClickHandler(
     }
 }
 
+@NavPreview(route = Screen.Schedule::class, primary = true)
 @Preview
 @Composable
 fun ScheduleScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/settings/SettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/settings/SettingsScreen.kt
@@ -24,10 +24,14 @@ import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.github.skydoves.navgraph.annotations.NavDestination
+import com.github.skydoves.navgraph.annotations.NavPreview
+import dev.seabat.ramennote.ui.navigation.Screen
 import org.koin.compose.viewmodel.koinViewModel
 import ramennote.sharedui.generated.resources.Res
 import ramennote.sharedui.generated.resources.settings_title
 
+@NavDestination(route = Screen.Settings::class)
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModelContract = koinViewModel<SettingsViewModel>()
@@ -135,6 +139,7 @@ fun AppVersionPreview() {
     }
 }
 
+@NavPreview(route = Screen.Settings::class, primary = true)
 @Preview
 @Composable
 fun SettingsScreenPreview() {

--- a/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/settings/SettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/dev/seabat/ramennote/ui/screens/settings/SettingsScreen.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.seabat.ramennote.ui.components.AppBar
 import dev.seabat.ramennote.ui.theme.RamenNoteTheme
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 import com.github.skydoves.navgraph.annotations.NavDestination
 import com.github.skydoves.navgraph.annotations.NavPreview
 import dev.seabat.ramennote.ui.navigation.Screen


### PR DESCRIPTION
## 概要

compose-nav-graph プラグインを導入し、NavGraph Graph の Previews タブを全画面で表示できるようにする。

## 変更内容

- **compose-nav-graph プラグインを導入**（0.2.0）: SKIE・NavGraph をバージョンカタログに移行し、全画面に `@NavDestination` / `@NavPreview` アノテーションを追加
- **compose-nav-graph を 0.1.1 → 0.2.0 にアップデート**: パッケージ単位のフィーチャースコープ機能と KMP フィーチャーモジュールのサムネイル修正を取り込む
- **`@Preview` import を `org.jetbrains` → `androidx` に移行**（38ファイル）: Compose Multiplatform 1.9.0 で `org.jetbrains.compose.ui.tooling.preview.Preview` が deprecated になったため、`commonMain` 全体で `androidx.compose.ui.tooling.preview.Preview` に統一。compose-nav-graph 0.2.0 の KSP プロセッサが `androidx` 版のみを検索するため、この移行により Previews タブに 68 件全プレビューが表示されるようになる

## テスト

- `./gradlew :sharedUI:generatePreviewGallery` が成功し 68件レンダリングされることを確認
- NavGraph Graph の Previews タブに全画面のサムネイルが表示されることを確認
- `./gradlew :sharedUI:compileAndroidMain` がエラーなく通ることを確認