### PR TITLE
CLAUDE.md・README 更新と !! 演算子の requireNotNull 置き換え

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,16 +11,36 @@ KMP（Kotlin Multiplatform）のラーメン店管理アプリ。Android / iOS �
 - **Room**: 2.8.1（DB） / **Koin**: 4.1.1（DI） / **Ktor**: 3.3.0（HTTP）
 - **Coil**: 3.3.0（画像） / **Navigation Compose**: 2.9.0-rc01
 - **SKIE**: 0.10.6（iOS 連携）
+- **compose-nav-graph**: 0.2.0（NavGraph Graph ビュー / IDE プラグイン）
 - **Firebase AI / Gemini AI**: 0.7.0（Android のみ）
 - **Android SDK**: compileSdk 36, minSdk 24, targetSdk 36
 
 ## 実行コマンド
 ```bash
-./gradlew :composeApp:assembleDebug        # ビルド
-./gradlew ktlintCheck                      # lint チェック
-./gradlew ktlintFormat                     # lint 自動修正
-./gradlew :composeApp:testDebugUnitTest    # テスト
+./gradlew :androidApp:assembleDebug              # ビルド
+./gradlew ktlintCheck                            # lint チェック
+./gradlew ktlintFormat                           # lint 自動修正
+./gradlew :androidApp:testDebugUnitTest          # テスト
+./gradlew :sharedUI:generatePreviewGallery       # NavGraph Previews 生成（68件）
 ```
+
+## プロジェクト構造
+
+```
+ramen-note/
+├── sharedLogic/   # KMP ライブラリ: data / domain / config 層
+│   └── src/
+│       ├── commonMain/   # DB(Room), Repository, UseCase, API クライアント
+│       ├── androidMain/  # Android 固有実装
+│       └── iosMain/      # iOS 固有実装
+├── sharedUI/      # Compose Multiplatform ライブラリ: ui / di 層
+│   └── src/commonMain/   # 全画面・コンポーネント・ナビゲーション
+├── androidApp/    # Android アプリエントリーポイント（Application クラス等）
+├── iosApp/        # iOS アプリ（Swift / Xcode プロジェクト）
+└── gradle/        # バージョンカタログ（libs.versions.toml）
+```
+
+- `sharedLogic` / `sharedUI` 間の依存: `sharedUI` → `sharedLogic`
 
 ## アーキテクチャ
 クリーンアーキテクチャ + MVVM の3層構造: `UI → Domain → Data`
@@ -35,6 +55,14 @@ KMP（Kotlin Multiplatform）のラーメン店管理アプリ。Android / iOS �
 - **DataSource**: プラットフォーム固有処理は `expect/actual` + Contract パターン
 - **Database（Room）**: マイグレーション は `DataModule.common.kt` に記述。現在のバージョン: 5（AreaEntity, ShopEntity, ReportEntity）
 
+### @Preview / NavGraph アノテーション規約
+
+- **`@Preview` import は必ず `androidx` 版を使用**: `androidx.compose.ui.tooling.preview.Preview`
+  - `org.jetbrains.compose.ui.tooling.preview.Preview` は Compose Multiplatform 1.9.0 で deprecated。compose-nav-graph 0.2.0 の KSP プロセッサが `androidx` 版のみを検索するため統一必須
+- **画面 Composable には `@NavDestination` と `@NavPreview` を付与**: IDE の NavGraph Graph ビューに表示するために必要
+  - `@NavDestination`: ナビゲーショングラフのノードとして登録
+  - `@NavPreview`: NavGraph Previews タブにサムネイルを表示
+
 ## ファイル命名規則
 - **expect/actual**: `Xxxx.common.kt` / `Xxxx.android.kt` / `Xxxx.ios.kt`
 - **ViewModel**: `XxxxViewModelContract.kt` / `XxxxViewModel.kt` / `MockXxxxViewModel.kt`
@@ -43,17 +71,17 @@ KMP（Kotlin Multiplatform）のラーメン店管理アプリ。Android / iOS �
 
 ## DI（Koin）登録ルール
 
-エントリーポイント: `di/KoinHelper.kt` の `initKoin()`
+エントリーポイント: `sharedUI` の `di/KoinHelper.kt` の `initKoin()`
 
 | モジュール | ファイル | 登録方法 |
 |---|---|---|
-| `viewModelModule` | `ui/di/ViewModelModule.kt` | `viewModel { XxxxViewModel(get(), ...) }` |
-| `useCaseModule` | `domain/di/DomainModule.kt` | `single<Contract> { Impl(get(), ...) }` |
-| `repositoryModule` | `data/di/DataModule.common.kt` | `single<Contract> { Impl(get(), ...) }` |
-| `databaseModule` | `data/di/DataModule.common.kt` | `single<RamenNoteDatabase> { ... }` |
-| `dataSourceModule` | `data/di/DataModule.common.kt` | expect/actual で定義 |
-| `factoryModule` | `data/di/DataModule.common.kt` | expect/actual で定義 |
-| `uiModule` | `ui/di/UiModule.common.kt` | expect/actual で定義 |
+| `viewModelModule` | `sharedUI` `ui/di/ViewModelModule.kt` | `viewModel { XxxxViewModel(get(), ...) }` |
+| `useCaseModule` | `sharedLogic` `domain/di/DomainModule.kt` | `single<Contract> { Impl(get(), ...) }` |
+| `repositoryModule` | `sharedLogic` `data/di/DataModule.common.kt` | `single<Contract> { Impl(get(), ...) }` |
+| `databaseModule` | `sharedLogic` `data/di/DataModule.common.kt` | `single<RamenNoteDatabase> { ... }` |
+| `dataSourceModule` | `sharedLogic` `data/di/DataModule.common.kt` | expect/actual で定義 |
+| `factoryModule` | `sharedLogic` `data/di/DataModule.common.kt` | expect/actual で定義 |
+| `uiModule` | `sharedUI` `ui/di/UiModule.common.kt` | expect/actual で定義 |
 
 ## プラットフォーム固有 API
 **いずれかを変更した場合、もう一方のプラットフォームにも同等の変更が必要。**
@@ -63,9 +91,9 @@ KMP（Kotlin Multiplatform）のラーメン店管理アプリ。Android / iOS �
 
 ## 機密情報（API キー等）の管理
 - `local.properties` に機密値を定義（`.gitignore` 済み）
-- `composeApp/build.gradle.kts` の `generateBuildSecrets` タスクが `BuildSecrets.kt` を自動生成
+- `sharedLogic/build.gradle.kts` の `generateBuildSecrets` タスクが `BuildSecrets.kt` を自動生成
 - commonMain から `BuildSecrets.UNSPLASH_ACCESS_KEY` などで参照
-- `local.properties` と `composeApp/secrets/` への Claude Code からの編集は Hooks によりブロックされる
+- `local.properties`・`google-services.json`・`.env` への Claude Code からの編集は Hooks によりブロックされる
 
 ## ktlint 設定
 無効化ルール（`.editorconfig`）: `trailing-comma`、`function-signature`、`parameter-list-wrapping`、`expression-body-syntax`、`backing-property` / `property-naming`（`_xxx` StateFlow 許可）、`filename`（`logd.android.kt` 形式許可）、Composable 関数名の除外

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ RamenNote は、ラーメン店の情報をエリア別に管理し、訪問予�
 - **Coil**: 画像読み込み
 - **Navigation Compose**: 画面遷移
 - **SKIE**: Kotlin/Swift 連携（iOS）
+- **compose-nav-graph**: IDE の NavGraph Graph ビュー（ナビゲーション構造の可視化）
 - **Firebase**: Analytics・Crashlytics・AI・App Check（Android: Play Integrity / Debug、iOS: DeviceCheck / Debug）
 - **Gemini AI**: AI 機能（Android）
 
@@ -139,6 +140,17 @@ Windows:
   ```bash
   ./gradlew ktlintFormat
   ```
+
+### NavGraph Graph ビュー
+
+compose-nav-graph プラグイン（0.2.0）を導入しており、IDE の **NavGraph Graph** タブでナビゲーション構造を視覚的に確認できます。
+
+プレビューギャラリーの生成:
+```bash
+./gradlew :sharedUI:generatePreviewGallery
+```
+
+> **注意**: `@Preview` アノテーションは `androidx.compose.ui.tooling.preview.Preview` を使用してください。`org.jetbrains` 版は Compose Multiplatform 1.9.0 で deprecated となり、compose-nav-graph の KSP プロセッサが認識しません。
 
 ## Claude Code
 

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportUseCase.kt
@@ -29,7 +29,7 @@ class LoadFullReportUseCase(
                     else -> error("unexpected state")
                 },
             impression = report.impression,
-            date = report.date!!,
+            date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
             star = report.star,
             areaId = report.areaId
         )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByAreaUseCase.kt
@@ -28,7 +28,7 @@ class LoadFullReportsByAreaUseCase(
                         photoName = report.photoName,
                         imagePath = imagePath,
                         impression = report.impression,
-                        date = report.date!!,
+                        date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
                         star = report.star,
                         areaId = report.areaId
                     )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsByShopUseCase.kt
@@ -28,7 +28,7 @@ class LoadFullReportsByShopUseCase(
                         photoName = report.photoName,
                         imagePath = imagePath,
                         impression = report.impression,
-                        date = report.date!!,
+                        date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
                         star = report.star,
                         areaId = report.areaId
                     )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadFullReportsUseCase.kt
@@ -28,7 +28,7 @@ class LoadFullReportsUseCase(
                         photoName = report.photoName,
                         imagePath = imagePath,
                         impression = report.impression,
-                        date = report.date!!,
+                        date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
                         star = report.star,
                         areaId = report.areaId
                     )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadRecentFullReportsUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadRecentFullReportsUseCase.kt
@@ -32,7 +32,7 @@ class LoadRecentFullReportsUseCase(
                 photoName = report.photoName,
                 imagePath = imagePath,
                 impression = report.impression,
-                date = report.date!!,
+                date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
                 star = report.star,
                 areaId = report.areaId
             )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/LoadReportsByYearUseCase.kt
@@ -28,7 +28,7 @@ class LoadReportsByYearUseCase(
                         photoName = report.photoName,
                         imagePath = imagePath,
                         impression = report.impression,
-                        date = report.date!!,
+                        date = requireNotNull(report.date) { "report.date is null (id=${report.id})" },
                         star = report.star,
                         areaId = report.areaId
                     )

--- a/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
+++ b/sharedLogic/src/commonMain/kotlin/dev/seabat/ramennote/domain/usecase/ResolveShopLocationUseCase.kt
@@ -92,7 +92,7 @@ class ResolveShopLocationUseCase(
         }
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
-                val (lat, lng) = result.data!!
+                val (lat, lng) = requireNotNull(result.data) { "geocode result data is null" }
                 val newMapUrl = buildMapUrl(shop, lat, lng)
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
@@ -106,7 +106,7 @@ class ResolveShopLocationUseCase(
         val query = shop.mapUrl.substringAfter("query=").substringBefore("&").decodeURLQueryComponent()
         return when (val result = geocodingRepository.geocode(query)) {
             is RunStatus.Success -> {
-                val (lat, lng) = result.data!!
+                val (lat, lng) = requireNotNull(result.data) { "geocode result data is null" }
                 val newMapUrl = buildMapUrl(shop, lat, lng)
                 shopsRepository.updateMapUrl(shop.id, newMapUrl)
                 ShopLocation(shop, lat, lng)
@@ -126,7 +126,7 @@ class ResolveShopLocationUseCase(
     private suspend fun expandAndResolve(shop: Shop): ShopLocation? {
         val expandResult = expandShortUrlRepository.expand(shop.mapUrl)
         if (expandResult !is RunStatus.Success) return geocodeByShopName(shop)
-        val expandedUrl = expandResult.data!!
+        val expandedUrl = requireNotNull(expandResult.data) { "expanded URL is null" }
 
         // 1. /@lat,lng 形式を試みる
         if (expandedUrl.contains("/@")) {
@@ -151,7 +151,7 @@ class ResolveShopLocationUseCase(
         if (!address.isNullOrEmpty()) {
             when (val geocodeResult = geocodingRepository.geocode(address)) {
                 is RunStatus.Success -> {
-                    val (lat, lng) = geocodeResult.data!!
+                    val (lat, lng) = requireNotNull(geocodeResult.data) { "geocode result data is null" }
                     if (lat in 24.0..46.0 && lng in 122.0..154.0) {
                         val newMapUrl = buildMapUrl(shop, lat, lng)
                         shopsRepository.updateMapUrl(shop.id, newMapUrl)

--- a/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/gallery/SharedImage.ios.kt
+++ b/sharedUI/src/iosMain/kotlin/dev/seabat/ramennote/ui/gallery/SharedImage.ios.kt
@@ -33,10 +33,10 @@ actual class SharedImage(
     @OptIn(ExperimentalForeignApi::class)
     actual fun toByteArray(): ByteArray? =
         if (image != null) {
-            val imageData =
-                UIImageJPEGRepresentation(image, COMPRESSION_QUALITY)
-                    ?: throw IllegalArgumentException("image data is null")
-            val bytes = imageData.bytes ?: throw IllegalArgumentException("image bytes is null")
+            val imageData = requireNotNull(UIImageJPEGRepresentation(image, COMPRESSION_QUALITY)) {
+                "image data is null"
+            }
+            val bytes = requireNotNull(imageData.bytes) { "image bytes is null" }
             val length = imageData.length
 
             val data: CPointer<ByteVar> = bytes.reinterpret()


### PR DESCRIPTION
### 概要

NavGraph プラグイン導入（PR #89）の内容を開発ドキュメントに反映するとともに、`!!` 演算子をエラー文脈付きの `requireNotNull` に置き換えてデバッグ効率を向上させた。

### 主な変更点

**1. CLAUDE.md の更新**
- 技術スタックに `compose-nav-graph 0.2.0` を追記
- ビルド・テストコマンドを `:composeApp:` → `:androidApp:` に修正（旧モジュール名の誤記を解消）
- モジュール構成（`sharedLogic` / `sharedUI` / `androidApp`）を明記したプロジェクト構造セクションを新設
- `@Preview` は `androidx` 版必須・`@NavDestination`/`@NavPreview` 付与規約を追加
- DI テーブルに `sharedUI` / `sharedLogic` のモジュールプレフィックスを追記
- 機密情報管理の記述を実態（`sharedLogic/build.gradle.kts`）に合わせて修正

**2. README.md の更新**
- 技術スタックに `compose-nav-graph`（NavGraph Graph ビュー）を追記
- NavGraph Graph ビューのビルドコマンドと `@Preview` 注意点を追記

**3. `!!` 演算子の `requireNotNull` 置き換え**
- `LoadXxx UseCase` 6ファイル: `report.date!!` → レポート ID 付きエラーメッセージに変更
- `ResolveShopLocationUseCase`: `result.data!!` / `expandResult.data!!` → 4箇所を置き換え
- `SharedImage.ios.kt`: `?: throw IllegalArgumentException(...)` → `requireNotNull` に変更（2箇所）

### 影響範囲
- 新規ファイル: なし
- 変更ファイル: `.claude/CLAUDE.md`、`README.md`、UseCase 7ファイル、`SharedImage.ios.kt`
- 破壊的変更: なし